### PR TITLE
fix export main components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,11 @@ import MedicationStatement from './components/resources/MedicationStatement';
 import MedicationOrder from './components/resources/MedicationOrder';
 import Encounter from './components/resources/Encounter';
 
-var Resources = { Patient, Encounter, MedicationStatement, MedicationOrder };
-
-module.exports = {
-  Resources: Resources,
-  FhirResource: FhirResource,
-  MedicationStatement: MedicationStatement,
-  Patient: Patient,
-  MedicationOrder: MedicationOrder,
+export const Resources = {
+  Patient,
+  Encounter,
+  MedicationStatement,
+  MedicationOrder,
 };
+
+export { FhirResource, MedicationStatement, Patient, MedicationOrder };


### PR DESCRIPTION
we've seen an error that disallowed export from the module in CommonJS way (like module.exports) after a recent babel upgrade.

DONE: 
 - implement ES6 export module standard