### PR TITLE
Fix npm run start task

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "NODE_ENV=test jest",
     "test:coverage": "NODE_ENV=test jest --coverage .",
     "test:watch": "NODE_ENV=test jest --watchAll .",
-    "start": "NODE_ENV=development webpack --watch",
+    "start": "NODE_ENV=production webpack --watch",
     "build": "NODE_ENV=production webpack",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",


### PR DESCRIPTION
Issue: https://github.com/1uphealth/fhir-react/pull/20

DONE:

- Set NODE_ENV to production in npm run start task.
- This fixes a "require is not defined" error when importing the library in 1upwebapp.

SCREENSHOTS:

![localhost_3000_dashboard](https://user-images.githubusercontent.com/58418992/70428458-e6de1a80-1a76-11ea-9e96-39ed45bcc8f5.png)
