### PR TITLE
Remove unused code

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,15 @@
   "presets": ["@babel/preset-env", "@babel/preset-react"],
   "plugins": [
     "@babel/plugin-proposal-object-rest-spread",
-    "@babel/plugin-transform-react-jsx"
+    "@babel/plugin-transform-react-jsx",
+    [
+      "transform-imports",
+      {
+        "lodash": {
+          "transform": "lodash/${member}",
+          "preventFullImport": true
+        }
+      }
+    ]
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6107,6 +6107,11 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "chokidar": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
@@ -6933,6 +6938,11 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -10745,8 +10755,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -13056,6 +13065,16 @@
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
       "integrity": "sha512-pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==",
       "dev": true
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5229,6 +5229,16 @@
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
+    "babel-plugin-transform-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-imports/-/babel-plugin-transform-imports-2.0.0.tgz",
+      "integrity": "sha512-65ewumYJ85QiXdcB/jmiU0y0jg6eL6CdnDqQAqQ8JMOKh1E52VPG3NJzbVKWcgovUR5GBH8IWpCXQ7I8Q3wjgw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4",
+        "is-valid-path": "^0.1.1"
+      }
+    },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
@@ -10866,6 +10876,32 @@
       "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
       "dev": true
     },
+    "is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -10964,6 +11000,15 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
+      "dev": true,
+      "requires": {
+        "is-invalid-path": "^0.1.0"
+      }
     },
     "is-whitespace-character": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.15",
+    "md5": "^2.2.1",
     "pretty-bytes": "^5.3.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0"

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
+    "babel-plugin-transform-imports": "^2.0.0",
     "css-loader": "^3.4.2",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",

--- a/src/components/resources/FamilyMemberHistory/FamilyMemberHistory.js
+++ b/src/components/resources/FamilyMemberHistory/FamilyMemberHistory.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ResourceContainer from '../../containers/ResourceContainer';
 import Coding from '../../datatypes/Coding';
-var _ = require('lodash');
+import _get from 'lodash/get';
 
 // {
 //   "detail": {
@@ -30,13 +30,13 @@ class FamilyMemberHistoryAddresses extends React.Component {
       <div className="mb-2">
         <h6 className="mb-0">
           <strong>
-            {_.get(this.props.fhirData, 'detail.code.text') ||
-              _.get(this.props.fhirData, 'detail.code.coding[0].code')}
+            {_get(this.props.fhirData, 'detail.code.text') ||
+              _get(this.props.fhirData, 'detail.code.coding[0].code')}
           </strong>
         </h6>
-        {typeof _.get(this.props.fhirData, 'detail.category') === 'undefined'
+        {typeof _get(this.props.fhirData, 'detail.category') === 'undefined'
           ? ''
-          : (_.get(this.props.fhirData, 'detail.category').coding || []).map(
+          : (_get(this.props.fhirData, 'detail.category').coding || []).map(
               function(coding) {
                 return <Coding fhirData={coding} />;
               },
@@ -54,13 +54,13 @@ class FamilyMemberHistoryActivity extends React.Component {
       <div className="mb-2">
         <h6 className="mb-0">
           <strong>
-            {_.get(this.props.fhirData, 'detail.code.text') ||
-              _.get(this.props.fhirData, 'detail.code.coding[0].code')}
+            {_get(this.props.fhirData, 'detail.code.text') ||
+              _get(this.props.fhirData, 'detail.code.coding[0].code')}
           </strong>
         </h6>
-        {typeof _.get(this.props.fhirData, 'detail.category') === 'undefined'
+        {typeof _get(this.props.fhirData, 'detail.category') === 'undefined'
           ? ''
-          : (_.get(this.props.fhirData, 'detail.category').coding || []).map(
+          : (_get(this.props.fhirData, 'detail.category').coding || []).map(
               function(coding) {
                 return <Coding fhirData={coding} />;
               },
@@ -76,36 +76,36 @@ class FamilyMemberHistory extends React.Component {
       <div>
         <ResourceContainer {...this.props}>
           <div style={{ width: '100%', display: 'inline-block' }}>
-            <h4 style={{ display: 'inline-block' }}>{`${_.get(
+            <h4 style={{ display: 'inline-block' }}>{`${_get(
               this.props.fhirResource,
               'condition[0].code.text',
             ) ||
-              _.get(
+              _get(
                 this.props.fhirResource,
                 'condition[0].code.coding[0].display',
               )}`}</h4>
             &nbsp;(
-            {_.get(this.props.fhirResource, 'relationship.coding[0].display') ||
-              _.get(this.props.fhirResource, 'relationship.text') ||
+            {_get(this.props.fhirResource, 'relationship.coding[0].display') ||
+              _get(this.props.fhirResource, 'relationship.text') ||
               ''}
             <span className="text-muted">
-              {typeof _.get(this.props.fhirResource, 'date') === 'undefined'
+              {typeof _get(this.props.fhirResource, 'date') === 'undefined'
                 ? ''
-                : `, on ${_.get(this.props.fhirResource, 'date')}`}
+                : `, on ${_get(this.props.fhirResource, 'date')}`}
             </span>
             )
           </div>
           <div className="container">
             <div className="row">
-              {typeof _.get(
+              {typeof _get(
                 this.props.fhirResource,
                 'condition[0].note.text',
               ) === 'undefined'
                 ? ''
-                : _.get(this.props.fhirResource, 'condition[0].note.text')}
+                : _get(this.props.fhirResource, 'condition[0].note.text')}
             </div>
             <div className="row">
-              {typeof _.get(this.props.fhirResource, 'status') ===
+              {typeof _get(this.props.fhirResource, 'status') ===
               'undefined' ? (
                 ''
               ) : (
@@ -117,9 +117,9 @@ class FamilyMemberHistory extends React.Component {
               )}
             </div>
             <div className="row">
-              {typeof _.get(this.props.fhirResource, 'status') === 'undefined'
+              {typeof _get(this.props.fhirResource, 'status') === 'undefined'
                 ? ''
-                : _.get(this.props.fhirResource, 'status')}
+                : _get(this.props.fhirResource, 'status')}
             </div>
           </div>
         </ResourceContainer>

--- a/src/components/resources/Generic/Generic.js
+++ b/src/components/resources/Generic/Generic.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ResourceContainer from '../../containers/ResourceContainer';
-var _ = require('lodash');
+import _get from 'lodash/get';
 
 class Condition extends React.Component {
   render() {
@@ -9,12 +9,12 @@ class Condition extends React.Component {
         <ResourceContainer {...this.props}>
           <div className="container">
             <h4>
-              {`${this.props.fhirResource.resourceType}/${_.get(
+              {`${this.props.fhirResource.resourceType}/${_get(
                 this.props.fhirResource,
                 'id',
               )}`}{' '}
-              {_.get(this.props.fhirResource, 'code.coding[0].display') ||
-                _.get(this.props.fhirResource, 'code.text') ||
+              {_get(this.props.fhirResource, 'code.coding[0].display') ||
+                _get(this.props.fhirResource, 'code.text') ||
                 ''}
             </h4>
           </div>

--- a/src/components/resources/MedicationOrder/MedicationOrder.js
+++ b/src/components/resources/MedicationOrder/MedicationOrder.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ResourceContainer from '../../containers/ResourceContainer';
-var _ = require('lodash');
+import _get from 'lodash/get';
 
 class MedicationDetails extends React.Component {
   render() {
@@ -20,8 +20,8 @@ class MedicationOrder extends React.Component {
           <div>
             <MedicationDetails
               medication={
-                _.get(this.props.fhirResource, 'medicationReference.display') ||
-                _.get(this.props.fhirResource, 'medicationCodeableConcept.text')
+                _get(this.props.fhirResource, 'medicationReference.display') ||
+                _get(this.props.fhirResource, 'medicationCodeableConcept.text')
               }
             />
           </div>
@@ -31,7 +31,7 @@ class MedicationOrder extends React.Component {
               <div>
                 {' '}
                 <b>Reason:</b>{' '}
-                {_.get(
+                {_get(
                   this.props.fhirResource.reasonCodeableConcept.coding[0],
                   'display',
                 )}{' '}
@@ -46,7 +46,7 @@ class MedicationOrder extends React.Component {
               <div>
                 {' '}
                 <b>Dosage Instruction:</b>{' '}
-                {_.get(this.props.fhirResource.dosageInstruction[0], 'text')}{' '}
+                {_get(this.props.fhirResource.dosageInstruction[0], 'text')}{' '}
               </div>
             ) : (
               ''
@@ -60,7 +60,7 @@ class MedicationOrder extends React.Component {
               <div>
                 {' '}
                 <b>Additional Information:</b>{' '}
-                {_.get(
+                {_get(
                   this.props.fhirResource.dosageInstruction[0]
                     .additionalInstructions,
                   'text',
@@ -78,7 +78,7 @@ class MedicationOrder extends React.Component {
               <div>
                 {' '}
                 <b>Additional Information:</b>{' '}
-                {_.get(
+                {_get(
                   this.props.fhirResource.dosageInstruction[0]
                     .additionalInstructions,
                   'text',
@@ -96,7 +96,7 @@ class MedicationOrder extends React.Component {
                 <div>
                   {' '}
                   <b>Route:</b>{' '}
-                  {_.get(
+                  {_get(
                     this.props.fhirResource.dosageInstruction[0].route
                       .coding[0],
                     'display',

--- a/src/components/resources/Patient/Patient.js
+++ b/src/components/resources/Patient/Patient.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import crypto from 'crypto';
 import _get from 'lodash/get';
+import md5 from 'md5';
 
 import HumanName from '../../datatypes/HumanName';
 import Telecom from '../../datatypes/Telecom';
@@ -26,10 +26,7 @@ function Patient(props) {
   const { fhirResource } = props;
 
   const id = _get(fhirResource, 'id');
-  const idHash = crypto
-    .createHash('md5')
-    .update(id || '')
-    .digest('hex');
+  const idHash = md5(id || '');
   const avatarSrc = `http://www.gravatar.com/avatar/${idHash}?s=50&r=any&default=identicon&forcedefault=1`;
   const patientNames = _get(fhirResource, 'name', []);
   const patientBirthDate = _get(fhirResource, 'birthDate');

--- a/src/components/resources/Practitioner/Practitioner.js
+++ b/src/components/resources/Practitioner/Practitioner.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import crypto from 'crypto';
+import md5 from 'md5';
 import _get from 'lodash/get';
 import _has from 'lodash/has';
 
@@ -91,10 +91,9 @@ const Practitioner = props => {
       <Header>
         <img
           className="fhir-resource__Practitioner__practitioner-avatar"
-          src={`http://www.gravatar.com/avatar/${crypto
-            .createHash('md5')
-            .update(id)
-            .digest('hex')}?s=30&r=any&default=identicon&forcedefault=1`}
+          src={`http://www.gravatar.com/avatar/${md5(
+            id,
+          )}?s=30&r=any&default=identicon&forcedefault=1`}
           alt=""
         />
         <Title>


### PR DESCRIPTION
Issue: #71 

By replacing large, mostly unused libraries with smaller alternatives, the total bundled JavaScript size was drastically decreased:

Before: 468K (137K gzipped)
After: 124K (26K gzipped) 

DONE:
- Use a smaller `md5` package instead of importing the entire `crypto`.
- Use `lodash/get` instead of the entire `lodash` when applicable.
- Guard against accidentally loading entire `lodash` as `_` in the future.