### PR TITLE
Add padding to storybook preview area

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -4,3 +4,9 @@
   integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
   crossorigin="anonymous"
 />
+
+<style>
+  .sb-show-main {
+    padding: 16px;
+  }
+</style>


### PR DESCRIPTION
DONE:
- Add 16px padding to storybook preview area. This makes previewing the components nicer since they don't immediately touch the content borders.

SCREENSHOTS:

Before:
![localhost_58056__path=_story_adverseevent--default-visualization-stu-3 (1)](https://user-images.githubusercontent.com/58418992/72739434-e96a7e80-3ba3-11ea-980c-2b8afb9312a3.png)

After:
![localhost_58056__path=_story_adverseevent--default-visualization-stu-3](https://user-images.githubusercontent.com/58418992/72739444-ecfe0580-3ba3-11ea-87be-18906b52258c.png)

