### PR TITLE
Money component

### DIFF
--- a/src/components/datatypes/Money/Money.js
+++ b/src/components/datatypes/Money/Money.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Money = props => {
+  const { fhirData } = props;
+  const { value, code } = fhirData;
+
+  return (
+    <span className="fhir-datatype__Money">
+      {value || ''}&nbsp;{code || ''}
+    </span>
+  );
+};
+
+Money.propTypes = {
+  fhirData: PropTypes.shape({}).isRequired,
+};
+
+export default Money;

--- a/src/components/datatypes/Money/Money.js
+++ b/src/components/datatypes/Money/Money.js
@@ -13,7 +13,10 @@ const Money = props => {
 };
 
 Money.propTypes = {
-  fhirData: PropTypes.shape({}).isRequired,
+  fhirData: PropTypes.shape({
+    value: PropTypes.number,
+    code: PropTypes.string,
+  }).isRequired,
 };
 
 export default Money;

--- a/src/components/datatypes/Money/index.js
+++ b/src/components/datatypes/Money/index.js
@@ -1,0 +1,3 @@
+import Money from './Money';
+
+export default Money;

--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
@@ -16,8 +16,9 @@ import {
   TableCell,
   MissingValue,
 } from '../../ui';
-import Date from '../../datatypes/Date';
 import Coding from '../../datatypes/Coding';
+import Date from '../../datatypes/Date';
+import Money from '../../datatypes/Money';
 
 const commonDTO = fhirResource => {
   const disposition = _get(fhirResource, 'disposition');
@@ -129,12 +130,12 @@ const ExplanationOfBenefit = props => {
         )}
         {totalCost && (
           <Value label="Total cost" data-testid="totalCost">
-            {totalCost.value || ''}&nbsp;{totalCost.code}
+            <Money fhirData={totalCost} />
           </Value>
         )}
         {totalBenefit && (
           <Value label="Total benefit" data-testid="totalBenefit">
-            {totalBenefit.value || ''}&nbsp;{totalBenefit.code}
+            <Money fhirData={totalBenefit} />
           </Value>
         )}
         {hasServices && (

--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.test.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.test.js
@@ -38,8 +38,12 @@ describe('should render ExplanationOfBenefit component properly', () => {
     expect(getByTestId('title').textContent).toContain('Claim settled as ');
     expect(getByTestId('created').textContent).toContain('2014-08-16');
     expect(getByTestId('insurer').textContent).toContain('Organization/2');
-    expect(getByTestId('totalCost').textContent).toContain('135.57');
-    expect(getByTestId('totalBenefit').textContent).toContain('96');
+    expect(
+      getByTestId('totalCost').textContent.replace(/\u00a0/g, ' '),
+    ).toEqual('135.57 USD');
+    expect(
+      getByTestId('totalBenefit').textContent.replace(/\u00a0/g, ' '),
+    ).toContain('96 USD');
     expect(getByTestId('hasServices').textContent).toContain('(1200)');
   });
 


### PR DESCRIPTION
Issue: #96 

DONE:
- Implement a small `Money` datatype component. It will be immediately useful in `Claim` (#96 ), and possibly in more future components.
- Use `Money` in existing `ExplanationOfBenefit`.

SCREENSHOTS:

<img width="224" alt="Screenshot 2020-01-21 at 10 39 17" src="https://user-images.githubusercontent.com/58418992/72793310-95f73f80-3c3a-11ea-8d5d-b15cc99543f6.png">
