### PR TITLE
Claim component

### DIFF
--- a/src/components/containers/FhirResource/FhirResource.js
+++ b/src/components/containers/FhirResource/FhirResource.js
@@ -6,6 +6,7 @@ import AllergyIntolerance from '../../resources/AllergyIntolerance/AllergyIntole
 import Binary from '../../resources/Binary';
 import CarePlan from '../../resources/CarePlan';
 import CareTeam from '../../resources/CareTeam';
+import Claim from '../../resources/Claim';
 import Condition from '../../resources/Condition';
 import Device from '../../resources/Device';
 import DiagnosticReport from '../../resources/DiagnosticReport';
@@ -91,6 +92,12 @@ class FhirResource extends React.Component {
         return (
           <ResourceContainer {...this.props}>
             <CareTeam {...this.props} />
+          </ResourceContainer>
+        );
+      case 'Claim':
+        return (
+          <ResourceContainer {...this.props}>
+            <Claim {...this.props} />
           </ResourceContainer>
         );
       case 'Condition':

--- a/src/components/resources/Claim/Claim.css
+++ b/src/components/resources/Claim/Claim.css
@@ -1,0 +1,12 @@
+.fhir-resource__Claim__item-level {
+  height: 100%;
+  height: 50px;
+  margin: -12px;
+  display: flex;
+}
+
+.fhir-resource__Claim__item-level-fill {
+  width: 10px;
+  height: 100%;
+  background: #dee2e6;
+}

--- a/src/components/resources/Claim/Claim.js
+++ b/src/components/resources/Claim/Claim.js
@@ -65,6 +65,8 @@ const dstu2DTO = fhirResource => {
     const claimResponse = insurance.claimResponse;
     return { focal, coverage, businessArrangement, claimResponse };
   });
+  const employmentImpacted = null;
+  const hospitalization = null;
   return {
     status,
     typeCoding,
@@ -75,6 +77,8 @@ const dstu2DTO = fhirResource => {
     diagnosis,
     accident,
     insurance,
+    employmentImpacted,
+    hospitalization,
   };
 };
 const stu3DTO = fhirResource => {
@@ -110,6 +114,21 @@ const stu3DTO = fhirResource => {
     const claimResponse = insurance.claimResponse;
     return { focal, coverage, businessArrangement, claimResponse };
   });
+  const employmentImpactedStart = _get(
+    fhirResource,
+    'employmentImpacted.start',
+  );
+  const employmentImpactedEnd = _get(fhirResource, 'employmentImpacted.end');
+  const employmentImpacted =
+    employmentImpactedStart || employmentImpactedEnd
+      ? { start: employmentImpactedStart, end: employmentImpactedEnd }
+      : null;
+  const hospitalizationStart = _get(fhirResource, 'hospitalization.start');
+  const hospitalizationEnd = _get(fhirResource, 'hospitalization.end');
+  const hospitalization =
+    hospitalizationStart || hospitalizationEnd
+      ? { start: hospitalizationStart, end: hospitalizationEnd }
+      : null;
   return {
     status,
     typeCoding,
@@ -120,6 +139,8 @@ const stu3DTO = fhirResource => {
     diagnosis,
     accident,
     insurance,
+    employmentImpacted,
+    hospitalization,
   };
 };
 
@@ -294,6 +315,8 @@ const Claim = props => {
     diagnosis,
     accident,
     insurance,
+    employmentImpacted,
+    hospitalization,
   } = fhirResourceData;
   const hasCareTeam = careTeam.length > 0;
   const hasDiagnosis = diagnosis.length > 0;
@@ -330,6 +353,36 @@ const Claim = props => {
               </Value>
             )}
           </ValueSection>
+        )}
+        {employmentImpacted && (
+          <Value label="Employment impacted" data-testid="employmentImpacted">
+            {employmentImpacted.start ? (
+              <DateType fhirData={employmentImpacted.start} />
+            ) : (
+              <MissingValue />
+            )}
+            {' - '}
+            {employmentImpacted.end ? (
+              <DateType fhirData={employmentImpacted.end} />
+            ) : (
+              <MissingValue />
+            )}
+          </Value>
+        )}
+        {hospitalization && (
+          <Value label="Hospitalization" data-testid="hospitalization">
+            {hospitalization.start ? (
+              <DateType fhirData={hospitalization.start} />
+            ) : (
+              <MissingValue />
+            )}
+            {' - '}
+            {hospitalization.end ? (
+              <DateType fhirData={hospitalization.end} />
+            ) : (
+              <MissingValue />
+            )}
+          </Value>
         )}
         {hasCareTeam && <CareTeam careTeam={careTeam} />}
         {hasDiagnosis && <Diagnosis diagnosis={diagnosis} />}

--- a/src/components/resources/Claim/Claim.js
+++ b/src/components/resources/Claim/Claim.js
@@ -1,0 +1,218 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _get from 'lodash/get';
+
+import Coding from '../../datatypes/Coding';
+import DateType from '../../datatypes/Date';
+import Reference from '../../datatypes/Reference';
+import UnhandledResourceDataStructure from '../UnhandledResourceDataStructure';
+import fhirVersions from '../fhirResourceVersions';
+
+import {
+  Root,
+  Header,
+  Title,
+  Badge,
+  BadgeSecondary,
+  Body,
+  MissingValue,
+  Value,
+  ValueSection,
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from '../../ui';
+
+const commonDTO = fhirResource => {
+  const id = _get(fhirResource, 'id');
+  const use = _get(fhirResource, 'use');
+  const created = _get(fhirResource, 'created');
+  const organization = _get(fhirResource, 'organization');
+  return { id, use, created, organization };
+};
+const dstu2DTO = fhirResource => {
+  const status = undefined;
+  const typeCoding = {
+    code: _get(fhirResource, 'type'),
+    system: 'http://hl7.org/fhir/ValueSet/claim-type-link',
+  };
+  const insurer = _get(fhirResource, 'target');
+  const payeeCoding = _get(fhirResource, 'payee.type');
+  const payeeParty =
+    _get(fhirResource, 'payee.provider') ||
+    _get(fhirResource, 'payee.organization') ||
+    _get(fhirResource, 'payee.person');
+  const careTeam = [];
+  const priorityCoding = _get(fhirResource, 'priority');
+  return {
+    status,
+    typeCoding,
+    insurer,
+    payee: { coding: payeeCoding, party: payeeParty },
+    careTeam,
+    priorityCoding,
+  };
+};
+const stu3DTO = fhirResource => {
+  const status = _get(fhirResource, 'status');
+  const typeCoding = _get(fhirResource, 'type.coding[0]');
+  const insurer = _get(fhirResource, 'insurer');
+  const payeeCoding = _get(fhirResource, 'payee.type.coding[0]');
+  const payeeParty = _get(fhirResource, 'payee.party');
+  const careTeam = _get(fhirResource, 'careTeam', []).map(team => {
+    const provider = team.provider;
+    const role = _get(team, 'role.coding[0]');
+    const qualification = _get(team, 'role.coding[0]');
+    return { provider, role, qualification };
+  });
+  const priorityCoding = _get(fhirResource, 'priority.coding[0]');
+  return {
+    status,
+    typeCoding,
+    insurer,
+    payee: { coding: payeeCoding, party: payeeParty },
+    careTeam,
+    priorityCoding,
+  };
+};
+
+const resourceDTO = (fhirVersion, fhirResource) => {
+  switch (fhirVersion) {
+    case fhirVersions.DSTU2: {
+      return {
+        ...commonDTO(fhirResource),
+        ...dstu2DTO(fhirResource),
+      };
+    }
+    case fhirVersions.STU3: {
+      return {
+        ...commonDTO(fhirResource),
+        ...stu3DTO(fhirResource),
+      };
+    }
+    default:
+      throw Error('Unrecognized the fhir version property type.');
+  }
+};
+
+const CareTeam = props => {
+  const { careTeam } = props;
+
+  return (
+    <ValueSection label="Care Team" data-testid="careTeam">
+      <Table>
+        <thead>
+          <TableRow>
+            <TableHeader>Role</TableHeader>
+            <TableHeader>Qualification</TableHeader>
+            <TableHeader>Provider</TableHeader>
+          </TableRow>
+        </thead>
+        <tbody>
+          {careTeam.map((member, idx) => (
+            <TableRow key={idx}>
+              <TableCell data-testid="careTeam.role">
+                {member.role ? (
+                  <Coding fhirData={member.role} />
+                ) : (
+                  <MissingValue />
+                )}
+              </TableCell>
+              <TableCell data-testid="careTeam.qualification">
+                {careTeam.qualification ? (
+                  <Coding fhirData={member.qualification} />
+                ) : (
+                  <MissingValue />
+                )}
+              </TableCell>
+              <TableCell data-testid="careTeam.provider">
+                <Reference fhirData={member.provider} />
+              </TableCell>
+            </TableRow>
+          ))}
+        </tbody>
+      </Table>
+    </ValueSection>
+  );
+};
+
+const Claim = props => {
+  const { fhirResource, fhirVersion } = props;
+  let fhirResourceData = {};
+  try {
+    fhirResourceData = resourceDTO(fhirVersion, fhirResource);
+  } catch (error) {
+    console.warn(error.message);
+    return <UnhandledResourceDataStructure resourceName="Claim" />;
+  }
+  const {
+    id,
+    status,
+    use,
+    typeCoding,
+    created,
+    insurer,
+    organization,
+    priorityCoding,
+    payee,
+    careTeam,
+  } = fhirResourceData;
+  const hasCareTeam = careTeam.length > 0;
+
+  return (
+    <Root name="Claim">
+      <Header>
+        <Title data-testid="title">Claim #{id}</Title>
+        {use && <Badge data-testid="use">{use}</Badge>}
+        {status && (
+          <BadgeSecondary data-testid="status">{status}</BadgeSecondary>
+        )}
+      </Header>
+      <Body>
+        <Value label="Type" data-testid="type">
+          <Coding fhirData={typeCoding} />
+        </Value>
+        {created && (
+          <Value label="Created at" data-testid="created">
+            <DateType fhirData={created} />
+          </Value>
+        )}
+        {priorityCoding && (
+          <Value label="Priority" data-testid="priority">
+            <Coding fhirData={priorityCoding} />
+          </Value>
+        )}
+        {insurer && (
+          <Value label="Insurer" data-testid="insurer">
+            <Reference fhirData={insurer} />
+          </Value>
+        )}
+        {organization && (
+          <Value label="Organization" data-testid="organization">
+            <Reference fhirData={organization} />
+          </Value>
+        )}
+        {payee.coding && (
+          <Value label="Payee" data-testid="payee.type">
+            <Coding fhirData={payee.coding} />
+          </Value>
+        )}
+        {payee.party && (
+          <Value label="Payee party" data-testid="payee.party">
+            <Reference fhirData={payee.party} />
+          </Value>
+        )}
+        {hasCareTeam && <CareTeam careTeam={careTeam} />}
+      </Body>
+    </Root>
+  );
+};
+
+Claim.propTypes = {
+  fhirResource: PropTypes.shape({}).isRequired,
+  fhirVersion: PropTypes.oneOf([fhirVersions.DSTU2, fhirVersions.STU3])
+    .isRequired,
+};
+
+export default Claim;

--- a/src/components/resources/Claim/Claim.js
+++ b/src/components/resources/Claim/Claim.js
@@ -9,6 +9,8 @@ import Reference from '../../datatypes/Reference';
 import UnhandledResourceDataStructure from '../UnhandledResourceDataStructure';
 import fhirVersions from '../fhirResourceVersions';
 
+import './Claim.css';
+
 import {
   Root,
   Header,
@@ -24,7 +26,6 @@ import {
   TableHeader,
   TableRow,
 } from '../../ui';
-import { nbspRegex } from '../../../testUtils';
 
 const commonDTO = fhirResource => {
   const id = _get(fhirResource, 'id');
@@ -336,11 +337,20 @@ const Insurance = props => {
 };
 
 const Item = props => {
-  const { item } = props;
+  const { item, level } = props;
+
+  const fill = Array(level)
+    .fill(null)
+    .map((_, idx) => (
+      <div key={idx} className="fhir-resource__Claim__item-level-fill"></div>
+    ));
 
   return (
     <>
       <TableRow>
+        <TableCell data-testid="items.level">
+          <div className="fhir-resource__Claim__item-level">{fill}</div>
+        </TableCell>
         <TableCell data-testid="items.service">
           <Coding fhirData={item.service} />
         </TableCell>
@@ -362,7 +372,7 @@ const Item = props => {
         </TableCell>
       </TableRow>
       {item.subItems.map((subItem, idx) => (
-        <Item key={idx} item={subItem} />
+        <Item key={idx} item={subItem} level={level + 1} />
       ))}
     </>
   );
@@ -376,6 +386,7 @@ const Items = props => {
       <Table>
         <thead>
           <TableRow>
+            <TableHeader />
             <TableHeader expand>Service</TableHeader>
             <TableHeader>Unit price</TableHeader>
             <TableHeader>Quantity</TableHeader>
@@ -384,7 +395,7 @@ const Items = props => {
         </thead>
         <tbody>
           {items.map((item, idx) => (
-            <Item key={idx} item={item} />
+            <Item key={idx} item={item} level={0} />
           ))}
         </tbody>
       </Table>

--- a/src/components/resources/Claim/Claim.js
+++ b/src/components/resources/Claim/Claim.js
@@ -52,6 +52,12 @@ const dstu2DTO = fhirResource => {
     const packageCodeCoding = null;
     return { coding, reference, typeCoding, packageCodeCoding };
   });
+  const accidentCoding = _get(fhirResource, 'accidentType');
+  const accidentDate = _get(fhirResource, 'accident');
+  const accident =
+    accidentCoding || accidentDate
+      ? { coding: accidentCoding, date: accidentDate }
+      : null;
   return {
     status,
     typeCoding,
@@ -60,6 +66,7 @@ const dstu2DTO = fhirResource => {
     careTeam,
     priorityCoding,
     diagnosis,
+    accident,
   };
 };
 const stu3DTO = fhirResource => {
@@ -82,6 +89,12 @@ const stu3DTO = fhirResource => {
     const packageCodeCoding = _get(diagnosis, 'packageCode.coding[0]');
     return { coding, reference, typeCoding, packageCodeCoding };
   });
+  const accidentCoding = _get(fhirResource, 'accident.type.coding[0]');
+  const accidentDate = _get(fhirResource, 'accident.date');
+  const accident =
+    accidentCoding || accidentDate
+      ? { coding: accidentCoding, date: accidentDate }
+      : null;
   return {
     status,
     typeCoding,
@@ -90,6 +103,7 @@ const stu3DTO = fhirResource => {
     careTeam,
     priorityCoding,
     diagnosis,
+    accident,
   };
 };
 
@@ -221,6 +235,7 @@ const Claim = props => {
     payee,
     careTeam,
     diagnosis,
+    accident,
   } = fhirResourceData;
   const hasCareTeam = careTeam.length > 0;
   const hasDiagnosis = diagnosis.length > 0;
@@ -267,6 +282,20 @@ const Claim = props => {
           <Value label="Payee party" data-testid="payee.party">
             <Reference fhirData={payee.party} />
           </Value>
+        )}
+        {accident && (
+          <ValueSection label="Accident" data-testid="accident">
+            {accident.date && (
+              <Value label="Date" data-testid="accident.date">
+                <DateType fhirData={accident.date} />
+              </Value>
+            )}
+            {accident.coding && (
+              <Value label="Type" data-testid="accident.type">
+                <Coding fhirData={accident.coding} />
+              </Value>
+            )}
+          </ValueSection>
         )}
         {hasCareTeam && <CareTeam careTeam={careTeam} />}
         {hasDiagnosis && <Diagnosis diagnosis={diagnosis} />}

--- a/src/components/resources/Claim/Claim.js
+++ b/src/components/resources/Claim/Claim.js
@@ -176,14 +176,17 @@ const CareTeam = props => {
       <Table>
         <thead>
           <TableRow>
+            <TableHeader>Provider</TableHeader>
             <TableHeader>Role</TableHeader>
             <TableHeader>Qualification</TableHeader>
-            <TableHeader>Provider</TableHeader>
           </TableRow>
         </thead>
         <tbody>
           {careTeam.map((member, idx) => (
             <TableRow key={idx}>
+              <TableCell data-testid="careTeam.provider">
+                <Reference fhirData={member.provider} />
+              </TableCell>
               <TableCell data-testid="careTeam.role">
                 {member.role ? (
                   <Coding fhirData={member.role} />
@@ -197,9 +200,6 @@ const CareTeam = props => {
                 ) : (
                   <MissingValue />
                 )}
-              </TableCell>
-              <TableCell data-testid="careTeam.provider">
-                <Reference fhirData={member.provider} />
               </TableCell>
             </TableRow>
           ))}

--- a/src/components/resources/Claim/Claim.js
+++ b/src/components/resources/Claim/Claim.js
@@ -4,6 +4,7 @@ import _get from 'lodash/get';
 
 import Coding from '../../datatypes/Coding';
 import DateType from '../../datatypes/Date';
+import Money from '../../datatypes/Money';
 import Reference from '../../datatypes/Reference';
 import UnhandledResourceDataStructure from '../UnhandledResourceDataStructure';
 import fhirVersions from '../fhirResourceVersions';
@@ -67,6 +68,7 @@ const dstu2DTO = fhirResource => {
   });
   const employmentImpacted = null;
   const hospitalization = null;
+  const total = null;
   return {
     status,
     typeCoding,
@@ -79,6 +81,7 @@ const dstu2DTO = fhirResource => {
     insurance,
     employmentImpacted,
     hospitalization,
+    total,
   };
 };
 const stu3DTO = fhirResource => {
@@ -129,6 +132,7 @@ const stu3DTO = fhirResource => {
     hospitalizationStart || hospitalizationEnd
       ? { start: hospitalizationStart, end: hospitalizationEnd }
       : null;
+  const total = _get(fhirResource, 'total');
   return {
     status,
     typeCoding,
@@ -141,6 +145,7 @@ const stu3DTO = fhirResource => {
     insurance,
     employmentImpacted,
     hospitalization,
+    total,
   };
 };
 
@@ -317,6 +322,7 @@ const Claim = props => {
     insurance,
     employmentImpacted,
     hospitalization,
+    total,
   } = fhirResourceData;
   const hasCareTeam = careTeam.length > 0;
   const hasDiagnosis = diagnosis.length > 0;
@@ -412,6 +418,11 @@ const Claim = props => {
           </Value>
         )}
         {hasInsurance && <Insurance insurance={insurance} />}
+        {total && (
+          <Value label="Total amount" data-testid="total">
+            <Money fhirData={total} />
+          </Value>
+        )}
       </Body>
     </Root>
   );

--- a/src/components/resources/Claim/Claim.stories.js
+++ b/src/components/resources/Claim/Claim.stories.js
@@ -7,6 +7,7 @@ import fhirVersions from '../fhirResourceVersions';
 import dstu2Example1 from '../../../fixtures/dstu2/resources/claim/example-1.json';
 import stu3Example1 from '../../../fixtures/stu3/resources/claim/example-1.json';
 import stu3Example2 from '../../../fixtures/stu3/resources/claim/example-2.json';
+import stu3Example3 from '../../../fixtures/stu3/resources/claim/example-3.json';
 
 export default {
   title: 'Claim',
@@ -24,5 +25,10 @@ export const ExampleOfSTU3 = () => {
 
 export const Example2OfSTU3 = () => {
   const fhirResource = object('Resource', stu3Example2);
+  return <Claim fhirVersion={fhirVersions.STU3} fhirResource={fhirResource} />;
+};
+
+export const Example3OfSTU3 = () => {
+  const fhirResource = object('Resource', stu3Example3);
   return <Claim fhirVersion={fhirVersions.STU3} fhirResource={fhirResource} />;
 };

--- a/src/components/resources/Claim/Claim.stories.js
+++ b/src/components/resources/Claim/Claim.stories.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { object } from '@storybook/addon-knobs';
+
+import Claim from './Claim';
+import fhirVersions from '../fhirResourceVersions';
+
+import dstu2Example1 from '../../../fixtures/dstu2/resources/claim/example-1.json';
+import stu3Example1 from '../../../fixtures/stu3/resources/claim/example-1.json';
+import stu3Example2 from '../../../fixtures/stu3/resources/claim/example-2.json';
+
+export default {
+  title: 'Claim',
+};
+
+export const ExampleOfDSTU2 = () => {
+  const fhirResource = object('Resource', dstu2Example1);
+  return <Claim fhirVersion={fhirVersions.DSTU2} fhirResource={fhirResource} />;
+};
+
+export const ExampleOfSTU3 = () => {
+  const fhirResource = object('Resource', stu3Example1);
+  return <Claim fhirVersion={fhirVersions.STU3} fhirResource={fhirResource} />;
+};
+
+export const Example2OfSTU3 = () => {
+  const fhirResource = object('Resource', stu3Example2);
+  return <Claim fhirVersion={fhirVersions.STU3} fhirResource={fhirResource} />;
+};

--- a/src/components/resources/Claim/Claim.test.js
+++ b/src/components/resources/Claim/Claim.test.js
@@ -28,6 +28,7 @@ describe('should render the Claim component properly', () => {
     expect(queryAllByTestId('careTeam')).toHaveLength(0);
     expect(queryAllByTestId('diagnosis')).toHaveLength(1);
     expect(queryAllByTestId('accident')).toHaveLength(0);
+    expect(queryAllByTestId('insurance')).toHaveLength(1);
   });
 
   it('with STU3 source data', () => {
@@ -49,6 +50,7 @@ describe('should render the Claim component properly', () => {
     expect(queryAllByTestId('careTeam')).toHaveLength(1);
     expect(queryAllByTestId('diagnosis')).toHaveLength(1);
     expect(queryAllByTestId('accident')).toHaveLength(0);
+    expect(queryAllByTestId('insurance')).toHaveLength(1);
   });
 
   it('including the members of the careTeam with STU3 source data', () => {
@@ -112,5 +114,30 @@ describe('should render the Claim component properly', () => {
     expect(getByTestId('accident.type').textContent).toContain(
       'Sporting Accident',
     );
+  });
+
+  it('including the insurance with STU3 source data', () => {
+    const defaultProps = {
+      fhirResource: stu3Example2,
+      fhirVersion: fhirVersions.STU3,
+    };
+    const { getAllByTestId, queryAllByTestId } = render(
+      <Claim {...defaultProps} />,
+    );
+
+    const coverage = getAllByTestId('insurance.coverage').map(
+      n => n.textContent,
+    );
+    const businessArrangement = getAllByTestId(
+      'insurance.businessArrangement',
+    ).map(n => n.textContent);
+    const claimResponse = getAllByTestId('insurance.claimResponse').map(
+      n => n.textContent,
+    );
+
+    expect(queryAllByTestId('insurance')).toHaveLength(1);
+    expect(coverage).toEqual(['Coverage/9876B1 (focal)']);
+    expect(businessArrangement).toEqual(['BA987123']);
+    expect(claimResponse).toEqual(['-']);
   });
 });

--- a/src/components/resources/Claim/Claim.test.js
+++ b/src/components/resources/Claim/Claim.test.js
@@ -27,6 +27,7 @@ describe('should render the Claim component properly', () => {
     expect(getByTestId('payee.type').textContent).toContain('provider');
     expect(queryAllByTestId('careTeam')).toHaveLength(0);
     expect(queryAllByTestId('diagnosis')).toHaveLength(1);
+    expect(queryAllByTestId('accident')).toHaveLength(0);
   });
 
   it('with STU3 source data', () => {
@@ -47,6 +48,7 @@ describe('should render the Claim component properly', () => {
     expect(getByTestId('payee.type').textContent).toContain('provider');
     expect(queryAllByTestId('careTeam')).toHaveLength(1);
     expect(queryAllByTestId('diagnosis')).toHaveLength(1);
+    expect(queryAllByTestId('accident')).toHaveLength(0);
   });
 
   it('including the members of the careTeam with STU3 source data', () => {
@@ -97,5 +99,18 @@ describe('should render the Claim component properly', () => {
     expect(diagnosis).toEqual(['654456']);
     expect(diagnosisTypes).toEqual(['admitting']);
     expect(diagnosisPackageCodes).toEqual(['Head trauma - concussion (400)']);
+  });
+
+  it('including the accident with STU3 source data', () => {
+    const defaultProps = {
+      fhirResource: stu3Example2,
+      fhirVersion: fhirVersions.STU3,
+    };
+    const { getByTestId } = render(<Claim {...defaultProps} />);
+
+    expect(getByTestId('accident.date').textContent).toEqual('2014-07-09');
+    expect(getByTestId('accident.type').textContent).toContain(
+      'Sporting Accident',
+    );
   });
 });

--- a/src/components/resources/Claim/Claim.test.js
+++ b/src/components/resources/Claim/Claim.test.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Claim from './Claim';
+import fhirVersions from '../fhirResourceVersions';
+import dstu2Example1 from '../../../fixtures/dstu2/resources/claim/example-1.json';
+import stu3Example1 from '../../../fixtures/stu3/resources/claim/example-1.json';
+import stu3Example2 from '../../../fixtures/stu3/resources/claim/example-2.json';
+
+describe('should render the Claim component properly', () => {
+  it('with DSTU2 source data', () => {
+    const defaultProps = {
+      fhirResource: dstu2Example1,
+      fhirVersion: fhirVersions.DSTU2,
+    };
+    const { getByTestId, queryAllByTestId } = render(
+      <Claim {...defaultProps} />,
+    );
+
+    expect(getByTestId('title').textContent).toEqual('Claim #100150');
+    expect(getByTestId('use').textContent).toEqual('complete');
+    expect(getByTestId('type').textContent).toContain('oral');
+    expect(getByTestId('created').textContent).toEqual('2014-08-16');
+    expect(getByTestId('priority').textContent).toContain('normal');
+    expect(getByTestId('insurer').textContent).toEqual('Organization/2');
+    expect(getByTestId('payee.type').textContent).toContain('provider');
+    expect(queryAllByTestId('careTeam')).toHaveLength(0);
+  });
+
+  it('with STU3 source data', () => {
+    const defaultProps = {
+      fhirResource: stu3Example1,
+      fhirVersion: fhirVersions.STU3,
+    };
+    const { getByTestId, queryAllByTestId } = render(
+      <Claim {...defaultProps} />,
+    );
+
+    expect(getByTestId('title').textContent).toEqual('Claim #100150');
+    expect(getByTestId('use').textContent).toEqual('complete');
+    expect(getByTestId('type').textContent).toContain('oral');
+    expect(getByTestId('created').textContent).toEqual('2014-08-16');
+    expect(getByTestId('priority').textContent).toContain('normal');
+    expect(getByTestId('insurer').textContent).toEqual('Organization/2');
+    expect(getByTestId('payee.type').textContent).toContain('provider');
+    expect(queryAllByTestId('careTeam')).toHaveLength(1);
+  });
+
+  it('including the members of the careTeam with STU3 source data', () => {
+    const defaultProps = {
+      fhirResource: stu3Example2,
+      fhirVersion: fhirVersions.STU3,
+    };
+    const { getAllByTestId, queryAllByTestId } = render(
+      <Claim {...defaultProps} />,
+    );
+
+    const roles = getAllByTestId('careTeam.role')
+      .map(n => n.textContent)
+      .map(t => t.replace(/[\s()]+/g, ''));
+    const qualifications = getAllByTestId('careTeam.qualification')
+      .map(n => n.textContent)
+      .map(t => t.replace(/[\s()]+/g, ''));
+    const providers = getAllByTestId('careTeam.provider').map(
+      n => n.textContent,
+    );
+
+    expect(queryAllByTestId('careTeam')).toHaveLength(1);
+    expect(roles).toEqual(['primary']);
+    expect(qualifications).toEqual(['-']);
+    expect(providers).toEqual(['Practitioner/example']);
+  });
+});

--- a/src/components/resources/Claim/Claim.test.js
+++ b/src/components/resources/Claim/Claim.test.js
@@ -140,4 +140,28 @@ describe('should render the Claim component properly', () => {
     expect(businessArrangement).toEqual(['BA987123']);
     expect(claimResponse).toEqual(['-']);
   });
+
+  it('including the employment impacted period with STU3 source data', () => {
+    const defaultProps = {
+      fhirResource: stu3Example2,
+      fhirVersion: fhirVersions.STU3,
+    };
+    const { getByTestId } = render(<Claim {...defaultProps} />);
+
+    expect(getByTestId('employmentImpacted').textContent).toEqual(
+      '2014-08-16 - 2014-08-16',
+    );
+  });
+
+  it('including the hospitalization period with STU3 source data', () => {
+    const defaultProps = {
+      fhirResource: stu3Example2,
+      fhirVersion: fhirVersions.STU3,
+    };
+    const { getByTestId } = render(<Claim {...defaultProps} />);
+
+    expect(getByTestId('hospitalization').textContent).toEqual(
+      '2014-08-15 - 2014-08-16',
+    );
+  });
 });

--- a/src/components/resources/Claim/Claim.test.js
+++ b/src/components/resources/Claim/Claim.test.js
@@ -164,4 +164,16 @@ describe('should render the Claim component properly', () => {
       '2014-08-15 - 2014-08-16',
     );
   });
+
+  it('including the total amount with STU3 source data', () => {
+    const defaultProps = {
+      fhirResource: stu3Example2,
+      fhirVersion: fhirVersions.STU3,
+    };
+    const { getByTestId } = render(<Claim {...defaultProps} />);
+
+    expect(getByTestId('total').textContent.replace(nbspRegex, ' ')).toEqual(
+      '125 USD',
+    );
+  });
 });

--- a/src/components/resources/Claim/Claim.test.js
+++ b/src/components/resources/Claim/Claim.test.js
@@ -7,6 +7,7 @@ import { nbspRegex } from '../../../testUtils';
 import dstu2Example1 from '../../../fixtures/dstu2/resources/claim/example-1.json';
 import stu3Example1 from '../../../fixtures/stu3/resources/claim/example-1.json';
 import stu3Example2 from '../../../fixtures/stu3/resources/claim/example-2.json';
+import stu3Example3 from '../../../fixtures/stu3/resources/claim/example-3.json';
 
 describe('should render the Claim component properly', () => {
   it('with DSTU2 source data', () => {
@@ -175,5 +176,55 @@ describe('should render the Claim component properly', () => {
     expect(getByTestId('total').textContent.replace(nbspRegex, ' ')).toEqual(
       '125 USD',
     );
+  });
+
+  it('including the items with STU3 source data', () => {
+    const defaultProps = {
+      fhirResource: stu3Example3,
+      fhirVersion: fhirVersions.STU3,
+    };
+    const { getAllByTestId } = render(<Claim {...defaultProps} />);
+
+    const services = getAllByTestId('items.service')
+      .map(n => n.textContent)
+      .map(t => t.replace(nbspRegex, ' '));
+    const unitPrices = getAllByTestId('items.unitPrice')
+      .map(n => n.textContent)
+      .map(t => t.replace(nbspRegex, ' '));
+    const quantities = getAllByTestId('items.quantity')
+      .map(n => n.textContent)
+      .map(t => t.replace(nbspRegex, ' '));
+    const netPrices = getAllByTestId('items.net')
+      .map(n => n.textContent)
+      .map(t => t.replace(nbspRegex, ' '));
+
+    expect(services).toEqual([
+      ' (glasses)',
+      ' (frame)',
+      ' (lens)',
+      ' (lens)',
+      ' (hardening)',
+      ' (UV coating)',
+      ' (fst)',
+    ]);
+    expect(unitPrices).toEqual([
+      '235.4 USD',
+      '100 USD × 1.1',
+      '55 USD',
+      '30 USD × 1.1',
+      '15 USD × 1.1',
+      '5 USD × 1.1',
+      '220 USD × 0.07',
+    ]);
+    expect(quantities).toEqual(['-', '-', '2', '2', '2', '2', '-']);
+    expect(netPrices).toEqual([
+      '235.4 USD',
+      '110 USD',
+      '110 USD',
+      '66 USD',
+      '33 USD',
+      '11 USD',
+      '15.4 USD',
+    ]);
   });
 });

--- a/src/components/resources/Claim/Claim.test.js
+++ b/src/components/resources/Claim/Claim.test.js
@@ -25,6 +25,7 @@ describe('should render the Claim component properly', () => {
     expect(getByTestId('insurer').textContent).toEqual('Organization/2');
     expect(getByTestId('payee.type').textContent).toContain('provider');
     expect(queryAllByTestId('careTeam')).toHaveLength(0);
+    expect(queryAllByTestId('diagnosis')).toHaveLength(1);
   });
 
   it('with STU3 source data', () => {
@@ -44,6 +45,7 @@ describe('should render the Claim component properly', () => {
     expect(getByTestId('insurer').textContent).toEqual('Organization/2');
     expect(getByTestId('payee.type').textContent).toContain('provider');
     expect(queryAllByTestId('careTeam')).toHaveLength(1);
+    expect(queryAllByTestId('diagnosis')).toHaveLength(1);
   });
 
   it('including the members of the careTeam with STU3 source data', () => {
@@ -69,5 +71,32 @@ describe('should render the Claim component properly', () => {
     expect(roles).toEqual(['primary']);
     expect(qualifications).toEqual(['-']);
     expect(providers).toEqual(['Practitioner/example']);
+  });
+
+  it('including the diagnosis with STU3 source data', () => {
+    const defaultProps = {
+      fhirResource: stu3Example2,
+      fhirVersion: fhirVersions.STU3,
+    };
+    const { getAllByTestId, queryAllByTestId } = render(
+      <Claim {...defaultProps} />,
+    );
+    // http://www.fileformat.info/info/unicode/char/00a0/index.htm
+    const nbsp = /\u00a0/g;
+
+    const diagnosis = getAllByTestId('diagnosis.diagnosis')
+      .map(n => n.textContent)
+      .map(t => t.replace(/[\s()]+/g, ''));
+    const diagnosisTypes = getAllByTestId('diagnosis.type')
+      .map(n => n.textContent)
+      .map(t => t.replace(/[\s()]+/g, ''));
+    const diagnosisPackageCodes = getAllByTestId('diagnosis.packageCode')
+      .map(n => n.textContent)
+      .map(t => t.replace(nbsp, ' '));
+
+    expect(queryAllByTestId('diagnosis')).toHaveLength(1);
+    expect(diagnosis).toEqual(['654456']);
+    expect(diagnosisTypes).toEqual(['admitting']);
+    expect(diagnosisPackageCodes).toEqual(['Head trauma - concussion (400)']);
   });
 });

--- a/src/components/resources/Claim/Claim.test.js
+++ b/src/components/resources/Claim/Claim.test.js
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 
 import Claim from './Claim';
 import fhirVersions from '../fhirResourceVersions';
+import { nbspRegex } from '../../../testUtils';
 import dstu2Example1 from '../../../fixtures/dstu2/resources/claim/example-1.json';
 import stu3Example1 from '../../../fixtures/stu3/resources/claim/example-1.json';
 import stu3Example2 from '../../../fixtures/stu3/resources/claim/example-2.json';
@@ -81,8 +82,6 @@ describe('should render the Claim component properly', () => {
     const { getAllByTestId, queryAllByTestId } = render(
       <Claim {...defaultProps} />,
     );
-    // http://www.fileformat.info/info/unicode/char/00a0/index.htm
-    const nbsp = /\u00a0/g;
 
     const diagnosis = getAllByTestId('diagnosis.diagnosis')
       .map(n => n.textContent)
@@ -92,7 +91,7 @@ describe('should render the Claim component properly', () => {
       .map(t => t.replace(/[\s()]+/g, ''));
     const diagnosisPackageCodes = getAllByTestId('diagnosis.packageCode')
       .map(n => n.textContent)
-      .map(t => t.replace(nbsp, ' '));
+      .map(t => t.replace(nbspRegex, ' '));
 
     expect(queryAllByTestId('diagnosis')).toHaveLength(1);
     expect(diagnosis).toEqual(['654456']);

--- a/src/components/resources/Claim/index.js
+++ b/src/components/resources/Claim/index.js
@@ -1,0 +1,3 @@
+import Claim from './Claim';
+
+export default Claim;

--- a/src/components/resources/DocumentReference/DocumentReference.test.js
+++ b/src/components/resources/DocumentReference/DocumentReference.test.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
+import { nbspRegex } from '../../../testUtils';
 import fhirVersions from '../fhirResourceVersions';
 import DocumentReference from './DocumentReference';
 
 import dstu2Example1 from '../../../fixtures/dstu2/resources/documentReference/example1.json';
 import stu3Example1 from '../../../fixtures/stu3/resources/documentReference/example1.json';
-
-// http://www.fileformat.info/info/unicode/char/00a0/index.htm
-const nbsp = /\u00a0/g;
 
 describe('should render the DocumentReference component properly', () => {
   it('should render with DSTU2 source data', () => {
@@ -23,19 +21,19 @@ describe('should render the DocumentReference component properly', () => {
     expect(getByTestId('status').textContent).toEqual('current');
     expect(getByTestId('docStatus').textContent).toEqual('preliminary');
     expect(getByTestId('createdAt').textContent).toEqual('2005-12-24');
-    expect(getByTestId('type').textContent.split(nbsp)).toEqual([
+    expect(getByTestId('type').textContent.split(nbspRegex)).toEqual([
       'Outpatient Note',
       '(34108-1)',
     ]);
-    expect(getByTestId('class').textContent.split(nbsp)).toEqual([
+    expect(getByTestId('class').textContent.split(nbspRegex)).toEqual([
       'History and Physical',
       '(History and Physical)',
     ]);
-    expect(getByTestId('securityLabel').textContent.split(nbsp)).toEqual([
+    expect(getByTestId('securityLabel').textContent.split(nbspRegex)).toEqual([
       'very restricted',
       '(V)',
     ]);
-    expect(getByTestId('context.event').textContent.split(nbsp)).toEqual([
+    expect(getByTestId('context.event').textContent.split(nbspRegex)).toEqual([
       'Arm',
       '(T-D8200)',
     ]);
@@ -49,7 +47,7 @@ describe('should render the DocumentReference component properly', () => {
       />,
     );
     const formats = getAllByTestId('content.format').map(node =>
-      node.textContent.split(nbsp),
+      node.textContent.split(nbspRegex),
     );
     expect(formats).toEqual([
       ['History and Physical Specification', '(urn:ihe:pcc:handp:2008)'],
@@ -74,19 +72,19 @@ describe('should render the DocumentReference component properly', () => {
     expect(getByTestId('status').textContent).toEqual('current');
     expect(getByTestId('docStatus').textContent).toEqual('preliminary');
     expect(getByTestId('createdAt').textContent).toEqual('2005-12-24');
-    expect(getByTestId('type').textContent.split(nbsp)).toEqual([
+    expect(getByTestId('type').textContent.split(nbspRegex)).toEqual([
       'Outpatient Note',
       '(34108-1)',
     ]);
-    expect(getByTestId('class').textContent.split(nbsp)).toEqual([
+    expect(getByTestId('class').textContent.split(nbspRegex)).toEqual([
       'History and Physical',
       '(History and Physical)',
     ]);
-    expect(getByTestId('securityLabel').textContent.split(nbsp)).toEqual([
+    expect(getByTestId('securityLabel').textContent.split(nbspRegex)).toEqual([
       'very restricted',
       '(V)',
     ]);
-    expect(getByTestId('context.event').textContent.split(nbsp)).toEqual([
+    expect(getByTestId('context.event').textContent.split(nbspRegex)).toEqual([
       'Arm',
       '(T-D8200)',
     ]);
@@ -100,7 +98,7 @@ describe('should render the DocumentReference component properly', () => {
       />,
     );
     const formats = getAllByTestId('content.format').map(node =>
-      node.textContent.split(nbsp),
+      node.textContent.split(nbspRegex),
     );
     expect(formats).toEqual([
       ['History and Physical Specification', '(urn:ihe:pcc:handp:2008)'],

--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.test.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import ExplanationOfBenefit from './ExplanationOfBenefit';
+import { nbspRegex } from '../../../testUtils';
 import fhirVersions from '../fhirResourceVersions';
 import dstu2Example1 from '../../../fixtures/dstu2/resources/explanationOfBenefit/example1.json';
 import example1Stu3 from '../../../fixtures/stu3/resources/explanationOfBenefit/example1.json';
@@ -39,10 +40,10 @@ describe('should render ExplanationOfBenefit component properly', () => {
     expect(getByTestId('created').textContent).toContain('2014-08-16');
     expect(getByTestId('insurer').textContent).toContain('Organization/2');
     expect(
-      getByTestId('totalCost').textContent.replace(/\u00a0/g, ' '),
+      getByTestId('totalCost').textContent.replace(nbspRegex, ' '),
     ).toEqual('135.57 USD');
     expect(
-      getByTestId('totalBenefit').textContent.replace(/\u00a0/g, ' '),
+      getByTestId('totalBenefit').textContent.replace(nbspRegex, ' '),
     ).toContain('96 USD');
     expect(getByTestId('hasServices').textContent).toContain('(1200)');
   });

--- a/src/components/ui/index.css
+++ b/src/components/ui/index.css
@@ -71,6 +71,10 @@
   border-bottom: 2px solid #dee2e6;
 }
 
+.fhir-ui__TableHeader--expand {
+  width: 100%;
+}
+
 .fhir-ui__Table tbody + tbody {
   border-top: 2px solid #dee2e6;
 }

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -43,9 +43,12 @@ export const Table = props => (
   <table className="fhir-ui__Table">{props.children}</table>
 );
 
-export const TableHeader = props => (
-  <th className="fhir-ui__TableHeader">{props.children}</th>
-);
+export const TableHeader = props => {
+  const { expand } = props;
+  let className = 'fhir-ui__TableHeader';
+  if (expand) className += ' fhir-ui__TableHeader--expand';
+  return <th className={className}>{props.children}</th>;
+};
 
 export const TableRow = props => (
   <tr className="fhir-ui__TableRow">{props.children}</tr>

--- a/src/fixtures/dstu2/resources/claim/example-1.json
+++ b/src/fixtures/dstu2/resources/claim/example-1.json
@@ -1,0 +1,79 @@
+{
+  "resourceType": "Claim",
+  "id": "100150",
+  "text": {
+    "status": "generated",
+    "div": "<div>A human-readable rendering of the Oral Health Claim</div>"
+  },
+  "type": "oral",
+  "identifier": [
+    {
+      "system": "http://happyvalley.com/claim",
+      "value": "12345"
+    }
+  ],
+  "created": "2014-08-16",
+  "target": {
+    "reference": "Organization/2"
+  },
+  "organization": {
+    "reference": "Organization/1"
+  },
+  "use": "complete",
+  "priority": {
+    "code": "normal"
+  },
+  "payee": {
+    "type": {
+      "code": "provider"
+    }
+  },
+  "diagnosis": [
+    {
+      "sequence": 1,
+      "diagnosis": {
+        "code": "123456"
+      }
+    }
+  ],
+  "patient": {
+    "reference": "Patient/1"
+  },
+  "coverage": [
+    {
+      "sequence": 1,
+      "focal": true,
+      "coverage": {
+        "reference": "Coverage/9876B1"
+      },
+      "relationship": {
+        "code": "self"
+      }
+    }
+  ],
+  "item": [
+    {
+      "sequence": 1,
+      "type": {
+        "code": "service"
+      },
+      "provider": {
+        "reference": "Practitioner/example"
+      },
+      "service": {
+        "code": "1200"
+      },
+      "serviceDate": "2014-08-16",
+      "unitPrice": {
+        "value": 135.57,
+        "system": "urn:iso:std:iso:4217",
+        "code": "USD"
+      },
+      "net": {
+        "value": 135.57,
+        "system": "urn:iso:std:iso:4217",
+        "code": "USD"
+      }
+    }
+  ]
+}

--- a/src/fixtures/stu3/resources/claim/example-1.json
+++ b/src/fixtures/stu3/resources/claim/example-1.json
@@ -1,0 +1,105 @@
+{
+  "resourceType": "Claim",
+  "id": "100150",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A human-readable rendering of the Oral Health Claim</div>"
+  },
+  "identifier": [
+    {
+      "system": "http://happyvalley.com/claim",
+      "value": "12345"
+    }
+  ],
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/ex-claimtype",
+        "code": "oral"
+      }
+    ]
+  },
+  "use": "complete",
+  "patient": {
+    "reference": "Patient/1"
+  },
+  "created": "2014-08-16",
+  "insurer": {
+    "reference": "Organization/2"
+  },
+  "organization": {
+    "reference": "Organization/1"
+  },
+  "priority": {
+    "coding": [
+      {
+        "code": "normal"
+      }
+    ]
+  },
+  "payee": {
+    "type": {
+      "coding": [
+        {
+          "code": "provider"
+        }
+      ]
+    }
+  },
+  "careTeam": [
+    {
+      "sequence": 1,
+      "provider": {
+        "reference": "Practitioner/example"
+      }
+    }
+  ],
+  "diagnosis": [
+    {
+      "sequence": 1,
+      "diagnosisCodeableConcept": {
+        "coding": [
+          {
+            "code": "123456"
+          }
+        ]
+      }
+    }
+  ],
+  "insurance": [
+    {
+      "sequence": 1,
+      "focal": true,
+      "coverage": {
+        "reference": "Coverage/9876B1"
+      }
+    }
+  ],
+  "item": [
+    {
+      "sequence": 1,
+      "careTeamLinkId": [
+        1
+      ],
+      "service": {
+        "coding": [
+          {
+            "code": "1200"
+          }
+        ]
+      },
+      "servicedDate": "2014-08-16",
+      "unitPrice": {
+        "value": 135.57,
+        "system": "urn:iso:std:iso:4217",
+        "code": "USD"
+      },
+      "net": {
+        "value": 135.57,
+        "system": "urn:iso:std:iso:4217",
+        "code": "USD"
+      }
+    }
+  ]
+}

--- a/src/fixtures/stu3/resources/claim/example-2.json
+++ b/src/fixtures/stu3/resources/claim/example-2.json
@@ -1,0 +1,196 @@
+{
+  "resourceType": "Claim",
+  "id": "960151",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A human-readable rendering of the Claim</div>"
+  },
+  "identifier": [
+    {
+      "system": "http://happyhospital.com/claim",
+      "value": "96123451"
+    }
+  ],
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/ex-claimtype",
+        "code": "institutional"
+      }
+    ]
+  },
+  "use": "complete",
+  "patient": {
+    "reference": "Patient/1"
+  },
+  "billablePeriod": {
+    "start": "2014-08-15",
+    "end": "2014-08-16"
+  },
+  "created": "2014-08-16",
+  "enterer": {
+    "identifier": {
+      "system": "http://jurisdiction.org/facilities/HOSP1234/users",
+      "value": "UC1234"
+    }
+  },
+  "insurer": {
+    "reference": "Organization/2"
+  },
+  "provider": {
+    "identifier": {
+      "system": "http://npid.org/providerid",
+      "value": "NJ12345"
+    }
+  },
+  "organization": {
+    "reference": "Organization/1"
+  },
+  "priority": {
+    "coding": [
+      {
+        "code": "normal"
+      }
+    ]
+  },
+  "payee": {
+    "type": {
+      "coding": [
+        {
+          "code": "provider"
+        }
+      ]
+    }
+  },
+  "facility": {
+    "identifier": {
+      "system": "http://jurisdiction.org/facilities",
+      "value": "HOSP1234"
+    }
+  },
+  "careTeam": [
+    {
+      "sequence": 1,
+      "provider": {
+        "reference": "Practitioner/example"
+      },
+      "responsible": true,
+      "role": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/claim-careteamrole",
+            "code": "primary"
+          }
+        ]
+      },
+      "qualification": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/provider-qualification",
+            "code": "physician"
+          }
+        ]
+      }
+    }
+  ],
+  "diagnosis": [
+    {
+      "sequence": 1,
+      "diagnosisCodeableConcept": {
+        "coding": [
+          {
+            "code": "654456"
+          }
+        ]
+      },
+      "type": [
+        {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/ex-diagnosistype",
+              "code": "admitting"
+            }
+          ]
+        }
+      ],
+      "packageCode": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/ex-diagnosisrelatedgroup",
+            "code": "400",
+            "display": "Head trauma - concussion"
+          }
+        ]
+      }
+    }
+  ],
+  "insurance": [
+    {
+      "sequence": 1,
+      "focal": true,
+      "coverage": {
+        "reference": "Coverage/9876B1"
+      },
+      "businessArrangement": "BA987123",
+      "preAuthRef": [
+        "PA2014G56473"
+      ]
+    }
+  ],
+  "accident": {
+    "date": "2014-07-09",
+    "type": {
+      "coding": [
+        {
+          "system": "http://hl7.org/fhir/v3/ActIncidentCode",
+          "code": "SPT",
+          "display": "Sporting Accident"
+        }
+      ]
+    },
+    "locationAddress": {
+      "text": "Grouse Mountain Ski Hill"
+    }
+  },
+  "employmentImpacted": {
+    "start": "2014-08-16",
+    "end": "2014-08-16"
+  },
+  "hospitalization": {
+    "start": "2014-08-15",
+    "end": "2014-08-16"
+  },
+  "item": [
+    {
+      "sequence": 1,
+      "careTeamLinkId": [
+        1
+      ],
+      "service": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/ex-serviceproduct",
+            "code": "exam"
+          }
+        ]
+      },
+      "servicedDate": "2014-08-16",
+      "unitPrice": {
+        "value": 125.00,
+        "system": "urn:iso:std:iso:4217",
+        "code": "USD"
+      },
+      "net": {
+        "value": 125.00,
+        "system": "urn:iso:std:iso:4217",
+        "code": "USD"
+      }
+    }
+  ],
+  "total": {
+    "value": 125.00,
+    "system": "urn:iso:std:iso:4217",
+    "code": "USD"
+  }
+}

--- a/src/fixtures/stu3/resources/claim/example-3.json
+++ b/src/fixtures/stu3/resources/claim/example-3.json
@@ -1,0 +1,508 @@
+{
+  "resourceType": "Claim",
+  "id": "660152",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A human-readable rendering of the Vision Claim for Glasses</div>"
+  },
+  "contained": [
+    {
+      "resourceType": "ClaimResponse",
+      "id": "claimresponse-1",
+      "identifier": [
+        {
+          "system": "http://thebenefircompany.com/claimresponse",
+          "value": "CR6532875367"
+        }
+      ]
+    },
+    {
+      "resourceType": "Device",
+      "id": "device-frame"
+    },
+    {
+      "resourceType": "Device",
+      "id": "device-lens"
+    }
+  ],
+  "identifier": [
+    {
+      "system": "http://happysight.com/claim",
+      "value": "6612347"
+    }
+  ],
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/ex-claimtype",
+        "code": "vision"
+      }
+    ]
+  },
+  "use": "complete",
+  "patient": {
+    "reference": "Patient/1"
+  },
+  "created": "2014-08-16",
+  "insurer": {
+    "reference": "Organization/2"
+  },
+  "organization": {
+    "reference": "Organization/1"
+  },
+  "priority": {
+    "coding": [
+      {
+        "code": "normal"
+      }
+    ]
+  },
+  "prescription": {
+    "reference": "http://www.optdocs.com/prescription/12345"
+  },
+  "payee": {
+    "type": {
+      "coding": [
+        {
+          "code": "provider"
+        }
+      ]
+    }
+  },
+  "careTeam": [
+    {
+      "sequence": 1,
+      "provider": {
+        "reference": "Practitioner/example"
+      }
+    }
+  ],
+  "diagnosis": [
+    {
+      "sequence": 1,
+      "diagnosisCodeableConcept": {
+        "coding": [
+          {
+            "code": "654321"
+          }
+        ]
+      }
+    }
+  ],
+  "insurance": [
+    {
+      "sequence": 1,
+      "focal": false,
+      "coverage": {
+        "reference": "Coverage/9876B1"
+      },
+      "preAuthRef": [
+        "PR7652387237"
+      ],
+      "claimResponse": {
+        "reference": "#claimresponse-1"
+      }
+    },
+    {
+      "sequence": 2,
+      "focal": true,
+      "coverage": {
+        "reference": "Coverage/9876B1"
+      },
+      "preAuthRef": [
+        "AB543GTD7567"
+      ]
+    }
+  ],
+  "item": [
+    {
+      "sequence": 1,
+      "careTeamLinkId": [
+        1
+      ],
+      "revenue": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/ex-revenue-center",
+            "code": "0010",
+            "display": "Vision Clinic"
+          }
+        ]
+      },
+      "category": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/benefit-subcategory",
+            "code": "F6",
+            "display": "Vision Coverage"
+          }
+        ]
+      },
+      "service": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/ex-visionservice",
+            "code": "glasses"
+          }
+        ]
+      },
+      "modifier": [
+        {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/modifiers",
+              "code": "rooh"
+            }
+          ]
+        }
+      ],
+      "programCode": [
+        {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/ex-programcode",
+              "code": "none"
+            }
+          ]
+        }
+      ],
+      "servicedDate": "2014-08-16",
+      "unitPrice": {
+        "value": 235.40,
+        "system": "urn:iso:std:iso:4217",
+        "code": "USD"
+      },
+      "net": {
+        "value": 235.40,
+        "system": "urn:iso:std:iso:4217",
+        "code": "USD"
+      },
+      "detail": [
+        {
+          "sequence": 1,
+          "revenue": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/ex-revenue-center",
+                "code": "0010",
+                "display": "Vision Clinic"
+              }
+            ]
+          },
+          "category": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/benefit-subcategory",
+                "code": "F6",
+                "display": "Vision Coverage"
+              }
+            ]
+          },
+          "service": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/ex-visionservice",
+                "code": "frame"
+              }
+            ]
+          },
+          "modifier": [
+            {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/modifiers",
+                  "code": "rooh"
+                }
+              ]
+            }
+          ],
+          "unitPrice": {
+            "value": 100.00,
+            "system": "urn:iso:std:iso:4217",
+            "code": "USD"
+          },
+          "factor": 1.1,
+          "net": {
+            "value": 110.00,
+            "system": "urn:iso:std:iso:4217",
+            "code": "USD"
+          },
+          "udi": [
+            {
+              "reference": "#device-frame"
+            }
+          ]
+        },
+        {
+          "sequence": 2,
+          "revenue": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/ex-revenue-center",
+                "code": "0010",
+                "display": "Vision Clinic"
+              }
+            ]
+          },
+          "category": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/benefit-subcategory",
+                "code": "F6",
+                "display": "Vision Coverage"
+              }
+            ]
+          },
+          "service": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/ex-visionservice",
+                "code": "lens"
+              }
+            ]
+          },
+          "programCode": [
+            {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/ex-programcode",
+                  "code": "none"
+                }
+              ]
+            }
+          ],
+          "quantity": {
+            "value": 2
+          },
+          "unitPrice": {
+            "value": 55.00,
+            "system": "urn:iso:std:iso:4217",
+            "code": "USD"
+          },
+          "net": {
+            "value": 110.00,
+            "system": "urn:iso:std:iso:4217",
+            "code": "USD"
+          },
+          "subDetail": [
+            {
+              "sequence": 1,
+              "revenue": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/ex-revenue-center",
+                    "code": "0010",
+                    "display": "Vision Clinic"
+                  }
+                ]
+              },
+              "category": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/benefit-subcategory",
+                    "code": "F6",
+                    "display": "Vision Coverage"
+                  }
+                ]
+              },
+              "service": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/ex-visionservice",
+                    "code": "lens"
+                  }
+                ]
+              },
+              "modifier": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/modifiers",
+                      "code": "rooh"
+                    }
+                  ]
+                }
+              ],
+              "programCode": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/ex-programcode",
+                      "code": "none"
+                    }
+                  ]
+                }
+              ],
+              "quantity": {
+                "value": 2
+              },
+              "unitPrice": {
+                "value": 30.00,
+                "system": "urn:iso:std:iso:4217",
+                "code": "USD"
+              },
+              "factor": 1.1,
+              "net": {
+                "value": 66.00,
+                "system": "urn:iso:std:iso:4217",
+                "code": "USD"
+              },
+              "udi": [
+                {
+                  "reference": "#device-lens"
+                }
+              ]
+            },
+            {
+              "sequence": 2,
+              "revenue": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/ex-revenue-center",
+                    "code": "0010",
+                    "display": "Vision Clinic"
+                  }
+                ]
+              },
+              "category": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/benefit-subcategory",
+                    "code": "F6",
+                    "display": "Vision Coverage"
+                  }
+                ]
+              },
+              "service": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/ex-visionservice",
+                    "code": "hardening"
+                  }
+                ]
+              },
+              "modifier": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/modifiers",
+                      "code": "rooh"
+                    }
+                  ]
+                }
+              ],
+              "quantity": {
+                "value": 2
+              },
+              "unitPrice": {
+                "value": 15.00,
+                "system": "urn:iso:std:iso:4217",
+                "code": "USD"
+              },
+              "factor": 1.1,
+              "net": {
+                "value": 33.00,
+                "system": "urn:iso:std:iso:4217",
+                "code": "USD"
+              }
+            },
+            {
+              "sequence": 3,
+              "revenue": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/ex-revenue-center",
+                    "code": "0010",
+                    "display": "Vision Clinic"
+                  }
+                ]
+              },
+              "category": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/benefit-subcategory",
+                    "code": "F6",
+                    "display": "Vision Coverage"
+                  }
+                ]
+              },
+              "service": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/ex-visionservice",
+                    "code": "UV coating"
+                  }
+                ]
+              },
+              "modifier": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/modifiers",
+                      "code": "rooh"
+                    }
+                  ]
+                }
+              ],
+              "quantity": {
+                "value": 2
+              },
+              "unitPrice": {
+                "value": 5.00,
+                "system": "urn:iso:std:iso:4217",
+                "code": "USD"
+              },
+              "factor": 1.1,
+              "net": {
+                "value": 11.00,
+                "system": "urn:iso:std:iso:4217",
+                "code": "USD"
+              }
+            }
+          ]
+        },
+        {
+          "sequence": 3,
+          "revenue": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/ex-revenue-center",
+                "code": "0010",
+                "display": "Vision Clinic"
+              }
+            ]
+          },
+          "category": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/benefit-subcategory",
+                "code": "F6",
+                "display": "Vision Coverage"
+              }
+            ]
+          },
+          "service": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/ex-visionservice",
+                "code": "fst"
+              }
+            ]
+          },
+          "unitPrice": {
+            "value": 220.00,
+            "system": "urn:iso:std:iso:4217",
+            "code": "USD"
+          },
+          "factor": 0.07,
+          "net": {
+            "value": 15.40,
+            "system": "urn:iso:std:iso:4217",
+            "code": "USD"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -1,0 +1,2 @@
+// http://www.fileformat.info/info/unicode/char/00a0/index.htm
+export const nbspRegex = /\u00a0/g;


### PR DESCRIPTION
Issue: #96 

DONE:

- Implement the `Claim` resource component, including care team, diagnosis, accident, insurance, items,  and more data.
- Add the ability for ui/Table columns to expand (`TableHeader` `expand` prop).
- Extract `nbspRegex` value to a separate `testUtils.js` file.

SCREENSHOTS:

![localhost_63653__path=_story_claim--example-3-of-stu-3](https://user-images.githubusercontent.com/58418992/72887536-336e7400-3d0c-11ea-8d4f-c99ffc0ae4bf.png)
![localhost_63653__path=_story_claim--example-3-of-stu-3 (1)](https://user-images.githubusercontent.com/58418992/72887537-336e7400-3d0c-11ea-9e6f-3a5e6b3f17e5.png)