### PR TITLE
Markdown datatype component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7182,6 +7182,12 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -7443,6 +7449,11 @@
       "requires": {
         "domelementtype": "1"
       }
+    },
+    "dompurify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.7.tgz",
+      "integrity": "sha512-S3O0lk6rFJtO01ZTzMollCOGg+WAtCwS3U5E2WSDY/x/sy7q70RjEC4Dmrih5/UqzLLB9XoKJ8KqwBxaNvBu4A=="
     },
     "domutils": {
       "version": "1.5.1",
@@ -13098,6 +13109,11 @@
         "prop-types": "^15.6.2",
         "unquote": "^1.1.0"
       }
+    },
+    "marked": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
+      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ=="
     },
     "material-colors": {
       "version": "1.2.6",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "react": "^16.8.3"
   },
   "dependencies": {
+    "dompurify": "^2.0.7",
     "lodash": "^4.17.15",
+    "marked": "^0.8.0",
     "md5": "^2.2.1",
     "pretty-bytes": "^5.3.0",
     "prop-types": "^15.7.2",
@@ -84,6 +86,7 @@
     "babel-loader": "^8.0.6",
     "babel-plugin-transform-imports": "^2.0.0",
     "css-loader": "^3.4.2",
+    "dedent": "^0.7.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",
     "eslint-config-react-app": "^5.0.2",

--- a/src/components/datatypes/Markdown/Markdown.js
+++ b/src/components/datatypes/Markdown/Markdown.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import marked from 'marked';
+import DOMPurify from 'dompurify';
+
+const Markdown = props => {
+  const { fhirData } = props;
+  const markdown = String(fhirData);
+  let html = null;
+  try {
+    const unsafeHTML = marked(markdown, { gfm: true });
+    html = DOMPurify.sanitize(unsafeHTML);
+  } catch {}
+
+  const dangerouslySetInnerHTML = html ? { __html: html } : null;
+  const children = dangerouslySetInnerHTML ? null : markdown;
+
+  return (
+    <div
+      className="fhir-datatype__Markdown"
+      data-testid="markdown"
+      dangerouslySetInnerHTML={dangerouslySetInnerHTML}
+    >
+      {children}
+    </div>
+  );
+};
+
+Markdown.propTypes = {
+  fhirData: PropTypes.string.isRequired,
+};
+
+export default Markdown;

--- a/src/components/datatypes/Markdown/Markdown.test.js
+++ b/src/components/datatypes/Markdown/Markdown.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Markdown from './Markdown';
+import dedent from 'dedent';
+
+describe('should render Markdown correctly', () => {
+  it('when using regular markdown features', () => {
+    const markdown = dedent`
+      # Header
+
+      Paragraph one.
+
+      * Bullet point one
+      * Bullet point two
+    `;
+    const expectedHTML = dedent`
+      <h1 id="header">Header</h1>
+      <p>Paragraph one.</p>
+      <ul>
+      <li>Bullet point one</li>
+      <li>Bullet point two</li>
+      </ul>
+    `;
+
+    const { getByTestId } = render(<Markdown fhirData={markdown} />);
+    expect(getByTestId('markdown').innerHTML.trim()).toEqual(expectedHTML);
+  });
+
+  it('escaping the HTML', () => {
+    const markdown = dedent`
+      # Header
+
+      <script>alert("XSS")</script>
+    `;
+    const expectedHTML = dedent`
+      <h1 id="header">Header</h1>
+    `;
+
+    const { getByTestId } = render(<Markdown fhirData={markdown} />);
+    expect(getByTestId('markdown').innerHTML.trim()).toEqual(expectedHTML);
+  });
+});

--- a/src/components/datatypes/Markdown/index.js
+++ b/src/components/datatypes/Markdown/index.js
@@ -1,0 +1,3 @@
+import Markdown from './Markdown';
+
+export default Markdown;


### PR DESCRIPTION
Issue: #90 

DONE:
- Implement the Markdown datatype component.
  Markdown is transformed to HTML using `marked` package (with GitHub Flavored Markdown enabled, as per HL7.org recommendation), and sanitized using `DOMPurify` package.