### PR TITLE
Consistent fhirVersions usage

### DIFF
--- a/src/components/resources/AllergyIntolerance/AllergyIntolerance.stories.js
+++ b/src/components/resources/AllergyIntolerance/AllergyIntolerance.stories.js
@@ -6,22 +6,38 @@ import AllergyIntolerance from './AllergyIntolerance';
 import exampleAllergyIntoleranceDSTU2 from '../../../fixtures/dstu2/resources/allergyIntolerance/example1.json';
 import exampleAllergyIntoleranceSTU3 from '../../../fixtures/stu3/resources/allergyIntolerance/example1.json';
 import example2AllergyIntoleranceSTU3 from '../../../fixtures/stu3/resources/allergyIntolerance/example2.json';
+import fhirVersions from '../fhirResourceVersions';
 
 export default { title: 'AllergyIntolerance' };
 
 export const DefaultVisualizationDSTU2 = () => {
   const fhirResource = object('Resource', exampleAllergyIntoleranceDSTU2);
-  return <AllergyIntolerance fhirVersion="dstu2" fhirResource={fhirResource} />;
+  return (
+    <AllergyIntolerance
+      fhirVersion={fhirVersions.DSTU2}
+      fhirResource={fhirResource}
+    />
+  );
 };
 
 export const ExampleDiagnosticReportSTU3 = () => {
   const fhirResource = object('Resource', exampleAllergyIntoleranceSTU3);
-  return <AllergyIntolerance fhirVersion="stu3" fhirResource={fhirResource} />;
+  return (
+    <AllergyIntolerance
+      fhirVersion={fhirVersions.STU3}
+      fhirResource={fhirResource}
+    />
+  );
 };
 
 export const Example2DiagnosticReportSTU3 = () => {
   const fhirResource = object('Resource', example2AllergyIntoleranceSTU3);
-  return <AllergyIntolerance fhirVersion="stu3" fhirResource={fhirResource} />;
+  return (
+    <AllergyIntolerance
+      fhirVersion={fhirVersions.STU3}
+      fhirResource={fhirResource}
+    />
+  );
 };
 
 export const ExampleWithoutFhirVersionProperty = () => {

--- a/src/components/resources/CarePlan/CarePlan.stories.js
+++ b/src/components/resources/CarePlan/CarePlan.stories.js
@@ -6,22 +6,29 @@ import CarePlan from './CarePlan';
 import exampleCarePlanDSTU2 from '../../../fixtures/dstu2/resources/carePlan/example1.json';
 import exampleCarePlanSTU3 from '../../../fixtures/stu3/resources/carePlan/example1.json';
 import example2CarePlanSTU3 from '../../../fixtures/stu3/resources/carePlan/example2.json';
+import fhirVersions from '../fhirResourceVersions';
 
 export default { title: 'CarePlan' };
 
 export const DefaultVisualizationDSTU2 = () => {
   const fhirResource = object('Resource', exampleCarePlanDSTU2);
-  return <CarePlan fhirVersion="dstu2" fhirResource={fhirResource} />;
+  return (
+    <CarePlan fhirVersion={fhirVersions.DSTU2} fhirResource={fhirResource} />
+  );
 };
 
 export const ExampleCarePlanSTU3 = () => {
   const fhirResource = object('Resource', exampleCarePlanSTU3);
-  return <CarePlan fhirVersion="stu3" fhirResource={fhirResource} />;
+  return (
+    <CarePlan fhirVersion={fhirVersions.STU3} fhirResource={fhirResource} />
+  );
 };
 
 export const Example2CarePlanSTU3 = () => {
   const fhirResource = object('Resource', example2CarePlanSTU3);
-  return <CarePlan fhirVersion="stu3" fhirResource={fhirResource} />;
+  return (
+    <CarePlan fhirVersion={fhirVersions.STU3} fhirResource={fhirResource} />
+  );
 };
 
 export const ExampleWithoutFhirVersionProperty = () => {

--- a/src/components/resources/Coverage/Coverage.stories.js
+++ b/src/components/resources/Coverage/Coverage.stories.js
@@ -6,22 +6,29 @@ import Coverage from './Coverage';
 import exampleCoverageDstu2 from '../../../fixtures/dstu2/resources/coverage/example1.json';
 import exampleCoverageStu3 from '../../../fixtures/stu3/resources/coverage/example1.json';
 import example2CoverageStu3 from '../../../fixtures/stu3/resources/coverage/example2.json';
+import fhirVersions from '../fhirResourceVersions';
 
 export default { title: 'Coverage' };
 
 export const DefaultVisualizationDSTU2 = () => {
   const fhirResource = object('Resource', exampleCoverageDstu2);
-  return <Coverage fhirVersion="dstu2" fhirResource={fhirResource} />;
+  return (
+    <Coverage fhirVersion={fhirVersions.DSTU2} fhirResource={fhirResource} />
+  );
 };
 
 export const ExampleOfSTU3 = () => {
   const fhirResource = object('Resource', exampleCoverageStu3);
-  return <Coverage fhirVersion="stu3" fhirResource={fhirResource} />;
+  return (
+    <Coverage fhirVersion={fhirVersions.STU3} fhirResource={fhirResource} />
+  );
 };
 
 export const Example2OfSTU3 = () => {
   const fhirResource = object('Resource', example2CoverageStu3);
-  return <Coverage fhirVersion="stu3" fhirResource={fhirResource} />;
+  return (
+    <Coverage fhirVersion={fhirVersions.STU3} fhirResource={fhirResource} />
+  );
 };
 
 export const ExampleWithoutFhirVersionProperty = () => {

--- a/src/components/resources/Device/Device.stories.js
+++ b/src/components/resources/Device/Device.stories.js
@@ -5,9 +5,9 @@ import Device from './Device';
 
 import dstu2Example1 from '../../../fixtures/dstu2/resources/device/example.json';
 import dstu2Example2 from '../../../fixtures/dstu2/resources/device/example2.json';
-
 import stu3Example1 from '../../../fixtures/stu3/resources/device/example1.json';
 import stu3Example2 from '../../../fixtures/stu3/resources/device/example2.json';
+import fhirVersions from '../fhirResourceVersions';
 
 export default {
   title: 'Device',
@@ -15,21 +15,25 @@ export default {
 
 export const DefaultVisualizationDSTU2 = () => {
   const fhirResource = object('Resource', dstu2Example1);
-  return <Device fhirResource={fhirResource} fhirVersion="dstu2" />;
+  return (
+    <Device fhirResource={fhirResource} fhirVersion={fhirVersions.DSTU2} />
+  );
 };
 
 export const ExampleOfDSTU2 = () => {
   const fhirResource = object('Resource', dstu2Example2);
-  return <Device fhirResource={fhirResource} fhirVersion="dstu2" />;
+  return (
+    <Device fhirResource={fhirResource} fhirVersion={fhirVersions.DSTU2} />
+  );
 };
 
 export const Example1OfSTU3 = () => {
   const fhirResource = object('Resource', stu3Example1);
-  return <Device fhirResource={fhirResource} fhirVersion="stu3" />;
+  return <Device fhirResource={fhirResource} fhirVersion={fhirVersions.STU3} />;
 };
 export const Example2OfSTU3 = () => {
   const fhirResource = object('Resource', stu3Example2);
-  return <Device fhirResource={fhirResource} fhirVersion="stu3" />;
+  return <Device fhirResource={fhirResource} fhirVersion={fhirVersions.STU3} />;
 };
 
 export const ExampleWithoutFHIRVersionProperty = () => {

--- a/src/components/resources/DiagnosticReport/DiagnosticReport.stories.js
+++ b/src/components/resources/DiagnosticReport/DiagnosticReport.stories.js
@@ -5,17 +5,28 @@ import DiagnosticReport from './DiagnosticReport';
 
 import exampleDiagnosticReportDSTU2 from '../../../fixtures/dstu2/resources/diagnosticReport/example1.json';
 import exampleDiagnosticReportSTU3 from '../../../fixtures/stu3/resources/diagnosticReport/example1.json';
+import fhirVersions from '../fhirResourceVersions';
 
 export default { title: 'DiagnosticReport' };
 
 export const DefaultVisualizationDSTU2 = () => {
   const fhirResource = object('Resource', exampleDiagnosticReportDSTU2);
-  return <DiagnosticReport fhirVersion="dstu2" fhirResource={fhirResource} />;
+  return (
+    <DiagnosticReport
+      fhirVersion={fhirVersions.DSTU2}
+      fhirResource={fhirResource}
+    />
+  );
 };
 
 export const ExampleDiagnosticReportSTU3 = () => {
   const fhirResource = object('Resource', exampleDiagnosticReportSTU3);
-  return <DiagnosticReport fhirVersion="stu3" fhirResource={fhirResource} />;
+  return (
+    <DiagnosticReport
+      fhirVersion={fhirVersions.STU3}
+      fhirResource={fhirResource}
+    />
+  );
 };
 
 export const ExampleWithoutFhirVersionProperty = () => {

--- a/src/components/resources/Encounter/Encounter.stories.js
+++ b/src/components/resources/Encounter/Encounter.stories.js
@@ -7,6 +7,7 @@ import example1 from '../../../fixtures/dstu2/resources/encounter/example.json';
 import example2 from '../../../fixtures/dstu2/resources/encounter/example-2.json';
 import example_STU3 from '../../../fixtures/stu3/resources/encounter/example-1.json';
 import example2_STU3 from '../../../fixtures/stu3/resources/encounter/example-2.json';
+import fhirVersions from '../fhirResourceVersions';
 
 export default {
   title: 'Encounter',
@@ -14,22 +15,30 @@ export default {
 
 export const DefaultVisualizationDSTU2 = () => {
   const fhirResource = object('Resource', example1);
-  return <Encounter fhirVersion="dstu2" fhirResource={fhirResource} />;
+  return (
+    <Encounter fhirVersion={fhirVersions.DSTU2} fhirResource={fhirResource} />
+  );
 };
 
 export const ExampleWithoutParticipantsDSTU2 = () => {
   const fhirResource = object('Resource', example2);
-  return <Encounter fhirVersion="dstu2" fhirResource={fhirResource} />;
+  return (
+    <Encounter fhirVersion={fhirVersions.DSTU2} fhirResource={fhirResource} />
+  );
 };
 
 export const ExampleSTU3 = () => {
   const fhirResource = object('Resource', example_STU3);
-  return <Encounter fhirVersion="stu3" fhirResource={fhirResource} />;
+  return (
+    <Encounter fhirVersion={fhirVersions.STU3} fhirResource={fhirResource} />
+  );
 };
 
 export const ExampleWithoutParticipantSTU3 = () => {
   const fhirResource = object('Resource', example2_STU3);
-  return <Encounter fhirVersion="stu3" fhirResource={fhirResource} />;
+  return (
+    <Encounter fhirVersion={fhirVersions.STU3} fhirResource={fhirResource} />
+  );
 };
 
 export const ExampleWithoutFHIRVersionProperty = () => {

--- a/src/components/resources/Goal/Goal.stories.js
+++ b/src/components/resources/Goal/Goal.stories.js
@@ -5,8 +5,8 @@ import Goal from './Goal';
 
 import dstu2Example1 from '../../../fixtures/dstu2/resources/goal/example1.json';
 import dstu2Example2 from '../../../fixtures/dstu2/resources/goal/example2.json';
-
 import stu3Example1 from '../../../fixtures/stu3/resources/goal/example1.json';
+import fhirVersions from '../fhirResourceVersions';
 
 export default {
   title: 'Goal',
@@ -14,17 +14,17 @@ export default {
 
 export const DefaultVisualizationDSTU2 = () => {
   const fhirResource = object('Resource', dstu2Example1);
-  return <Goal fhirVersion="dstu2" fhirResource={fhirResource} />;
+  return <Goal fhirVersion={fhirVersions.DSTU2} fhirResource={fhirResource} />;
 };
 
 export const Example2OfDSTU2 = () => {
   const fhirResource = object('Resource', dstu2Example2);
-  return <Goal fhirVersion="dstu2" fhirResource={fhirResource} />;
+  return <Goal fhirVersion={fhirVersions.DSTU2} fhirResource={fhirResource} />;
 };
 
 export const ExampleOfSTU3 = () => {
   const fhirResource = object('Resource', stu3Example1);
-  return <Goal fhirVersion="stu3" fhirResource={fhirResource} />;
+  return <Goal fhirVersion={fhirVersions.STU3} fhirResource={fhirResource} />;
 };
 
 export const ExampleWithoutFhirVersionProperty = () => {

--- a/src/components/resources/MedicationAdministration/MedicationAdministration.stories.js
+++ b/src/components/resources/MedicationAdministration/MedicationAdministration.stories.js
@@ -5,6 +5,7 @@ import MedicationAdministration from './MedicationAdministration';
 
 import dstu2Example1 from '../../../fixtures/dstu2/resources/medicationAdministration/example1.json';
 import stu3Example1 from '../../../fixtures/stu3/resources/medicationAdministration/example1.json';
+import fhirVersions from '../fhirResourceVersions';
 
 export default {
   title: 'MedicationAdministration',
@@ -13,13 +14,19 @@ export default {
 export const DefaultVisualizationDSTU2 = () => {
   const fhirResource = object('Resource', dstu2Example1);
   return (
-    <MedicationAdministration fhirVersion="dstu2" fhirResource={fhirResource} />
+    <MedicationAdministration
+      fhirVersion={fhirVersions.DSTU2}
+      fhirResource={fhirResource}
+    />
   );
 };
 
 export const ExampleOfSTU3 = () => {
   const fhirResource = object('Resource', stu3Example1);
   return (
-    <MedicationAdministration fhirVersion="stu3" fhirResource={fhirResource} />
+    <MedicationAdministration
+      fhirVersion={fhirVersions.STU3}
+      fhirResource={fhirResource}
+    />
   );
 };

--- a/src/components/resources/MedicationStatement/MedicationStatement.stories.js
+++ b/src/components/resources/MedicationStatement/MedicationStatement.stories.js
@@ -6,6 +6,7 @@ import MedicationStatement from './MedicationStatement';
 import dstu2Example1 from '../../../fixtures/dstu2/resources/medicationStatement/example1.json';
 import stu3Example1 from '../../../fixtures/stu3/resources/medicationStatement/example1.json';
 import stu3Example2 from '../../../fixtures/stu3/resources/medicationStatement/example2.json';
+import fhirVersions from '../fhirResourceVersions';
 
 export default {
   title: 'MedicationStatement',
@@ -14,16 +15,29 @@ export default {
 export const DefaultVisualizationDSTU2 = () => {
   const fhirResource = object('Resource', dstu2Example1);
   return (
-    <MedicationStatement fhirVersion="dstu2" fhirResource={fhirResource} />
+    <MedicationStatement
+      fhirVersion={fhirVersions.DSTU2}
+      fhirResource={fhirResource}
+    />
   );
 };
 
 export const ExampleOfSTU3 = () => {
   const fhirResource = object('Resource', stu3Example1);
-  return <MedicationStatement fhirVersion="stu3" fhirResource={fhirResource} />;
+  return (
+    <MedicationStatement
+      fhirVersion={fhirVersions.STU3}
+      fhirResource={fhirResource}
+    />
+  );
 };
 
 export const Example2OfSTU3 = () => {
   const fhirResource = object('Resource', stu3Example2);
-  return <MedicationStatement fhirVersion="stu3" fhirResource={fhirResource} />;
+  return (
+    <MedicationStatement
+      fhirVersion={fhirVersions.STU3}
+      fhirResource={fhirResource}
+    />
+  );
 };

--- a/src/components/resources/ReferralRequest/ReferralRequest.stories.js
+++ b/src/components/resources/ReferralRequest/ReferralRequest.stories.js
@@ -5,6 +5,7 @@ import ReferralRequest from './ReferralRequest';
 
 import dstu2Example1 from '../../../fixtures/dstu2/resources/referralRequest/example1.json';
 import stu3Example1 from '../../../fixtures/stu3/resources/referralRequest/example1.json';
+import fhirVersions from '../fhirResourceVersions';
 
 export default {
   title: 'ReferralRequest',
@@ -12,12 +13,22 @@ export default {
 
 export const DefaultVisualizationDSTU2 = () => {
   const fhirResource = object('Resource', dstu2Example1);
-  return <ReferralRequest fhirVersion="dstu2" fhirResource={fhirResource} />;
+  return (
+    <ReferralRequest
+      fhirVersion={fhirVersions.DSTU2}
+      fhirResource={fhirResource}
+    />
+  );
 };
 
 export const ExampleOfSTU3 = () => {
   const fhirResource = object('Resource', stu3Example1);
-  return <ReferralRequest fhirVersion="stu3" fhirResource={fhirResource} />;
+  return (
+    <ReferralRequest
+      fhirVersion={fhirVersions.STU3}
+      fhirResource={fhirResource}
+    />
+  );
 };
 
 export const ExampleWithoutFhirVersionProperty = () => {


### PR DESCRIPTION
DONE:
- Use `fhirVersions` constants in storybook stories, instead of hardcoded strings.