### PR TITLE
Add config to storybook to handle single quotes

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -10,6 +10,10 @@ addParameters({
   },
 });
 
-addDecorator(withKnobs);
+addDecorator(
+  withKnobs({
+    escapeHTML: false,
+  }),
+);
 
 configure(require.context('../src', true, /\.stories\.js$/), module);

--- a/src/components/resources/Encounter/Encounter.js
+++ b/src/components/resources/Encounter/Encounter.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import _get from 'lodash/get';
 import _has from 'lodash/has';
-import _unescape from 'lodash/unescape';
 import EncounterParticipants from './EncounterParticipants';
 import UnhandledResourceDataStructure from '../UnhandledResourceDataStructure';
 import fhirVersions from '../fhirResourceVersions';
@@ -22,12 +21,11 @@ import {
 
 const commonDTO = fhirResource => {
   const resourceStatus = _get(fhirResource, 'status');
-  const locationDisplayRaw = _get(
+  const locationDisplay = _get(
     fhirResource,
     'location[0].location.display',
     'Encounter',
   );
-  const locationDisplay = _unescape(locationDisplayRaw);
   const encounterType = _get(fhirResource, 'type');
   const hasParticipant = _has(fhirResource, 'participant');
   return {


### PR DESCRIPTION
Added the option to storybook to not escape single quotes in provided data

DONE:

Add option to storybook config to not escape HTML entities 
Remove local escaping of HTML entities from Encounter component