### PR TITLE
add R4 support to MedicationDispense component

### DIFF
--- a/src/components/resources/MedicationDispense/MedicationDispense.js
+++ b/src/components/resources/MedicationDispense/MedicationDispense.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _get from 'lodash/get';
 import Coding from '../../datatypes/Coding';
+import Date from '../../datatypes/Date';
 import UnhandledResourceDataStructure from '../UnhandledResourceDataStructure';
 import fhirVersions from '../fhirResourceVersions';
 
@@ -18,6 +19,7 @@ import {
   TableRow,
   MissingValue,
 } from '../../ui';
+import CodeableConcept from '../../datatypes/CodeableConcept/CodeableConcept';
 
 const DosageInstruction = props => {
   const empty = <MissingValue />;
@@ -29,19 +31,22 @@ const DosageInstruction = props => {
   } = props.item;
   return (
     <TableRow>
-      <TableCell>{timing}</TableCell>
-      <TableCell>{route}</TableCell>
-      <TableCell>{doseQuantity}</TableCell>
-      <TableCell>{additionalInstructions}</TableCell>
+      <TableCell data-testid="dosageTiming">{timing}</TableCell>
+      <TableCell data-testid="dosageRoute">{route}</TableCell>
+      <TableCell data-testid="dosageQuantity">{doseQuantity}</TableCell>
+      <TableCell data-testid="dosageAdditionalInstructions">
+        <CodeableConcept fhirData={additionalInstructions} />
+      </TableCell>
     </TableRow>
   );
 };
 
 const commonDTO = fhirResource => {
   const typeCoding = _get(fhirResource, 'type.coding.0');
-
+  const whenPrepared = _get(fhirResource, 'whenPrepared');
   return {
     typeCoding,
+    whenPrepared,
   };
 };
 
@@ -56,12 +61,8 @@ const dstu2DTO = fhirResource => {
           'doseQuantity.unit',
         )}`;
       }
-      if (_get(item, 'additionalInstructions')) {
-        data.additionalInstructions = _get(
-          item,
-          'additionalInstructions.coding.0.display',
-          '',
-        );
+      if (_get(item, 'additionalInstructions.coding')) {
+        data.additionalInstructions = _get(item, 'additionalInstructions', '');
       }
       const timingRepeat = _get(item, 'timing.repeat');
       if (timingRepeat) {
@@ -90,12 +91,46 @@ const stu3DTO = fhirResource => {
           'doseQuantity.unit',
         )}`;
       }
-      if (_get(item, 'additionalInstruction')) {
-        data.additionalInstructions = _get(
+      if (_get(item, 'additionalInstruction.0.coding')) {
+        data.additionalInstructions = _get(item, 'additionalInstruction.0', '');
+      }
+      const timingRepeat = _get(item, 'timing.repeat');
+      if (timingRepeat) {
+        data.timing = `${timingRepeat.period} / ${timingRepeat.periodUnit}`;
+      }
+
+      return data;
+    });
+  };
+  const medicationTitle =
+    _get(fhirResource, 'medicationReference.display') ||
+    _get(fhirResource, 'contained[0].code.coding[0].display');
+  const medicationCoding = _get(fhirResource, 'contained[0].code.coding[0]');
+  const dosageInstruction = _get(fhirResource, 'dosageInstruction', []);
+  const hasDosageInstruction =
+    Array.isArray(dosageInstruction) && dosageInstruction.length > 0;
+  const dosageInstructionData = prepareDosageInstructionData(dosageInstruction);
+  return {
+    medicationTitle,
+    medicationCoding,
+    hasDosageInstruction,
+    dosageInstructionData,
+  };
+};
+
+const r4DTO = fhirResource => {
+  const prepareDosageInstructionData = rawData => {
+    return rawData.map(item => {
+      const data = {};
+      data.route = _get(item, 'route.coding.0.display');
+      if (_get(item, 'doseAndRate.0.doseQuantity')) {
+        data.doseQuantity = `${_get(
           item,
-          'additionalInstruction.0.coding.0.display',
-          '',
-        );
+          'doseAndRate.0.doseQuantity.value',
+        )} ${_get(item, 'doseAndRate.0.doseQuantity.unit')}`;
+      }
+      if (_get(item, 'doseAndRate.0.type.coding')) {
+        data.additionalInstructions = _get(item, 'doseAndRate.0.type');
       }
       const timingRepeat = _get(item, 'timing.repeat');
       if (timingRepeat) {
@@ -135,6 +170,12 @@ const resourceDTO = (fhirVersion, fhirResource) => {
         ...stu3DTO(fhirResource),
       };
     }
+    case fhirVersions.R4: {
+      return {
+        ...commonDTO(fhirResource),
+        ...r4DTO(fhirResource),
+      };
+    }
 
     default:
       throw Error('Unrecognized the fhir version property type.');
@@ -157,6 +198,7 @@ const MedicationDispense = props => {
     typeCoding,
     hasDosageInstruction,
     dosageInstructionData,
+    whenPrepared,
   } = fhirResourceData;
 
   return (
@@ -170,6 +212,11 @@ const MedicationDispense = props => {
         {medicationCoding && (
           <Value label="Medication" data-testid="medicationCoding">
             <Coding fhirData={medicationCoding} />
+          </Value>
+        )}
+        {whenPrepared && (
+          <Value label="Prepared" data-testid="whenPrepared">
+            <Date fhirData={whenPrepared} />
           </Value>
         )}
         {typeCoding && (
@@ -203,8 +250,11 @@ const MedicationDispense = props => {
 
 MedicationDispense.propTypes = {
   fhirResource: PropTypes.shape({}).isRequired,
-  fhirVersion: PropTypes.oneOf([fhirVersions.DSTU2, fhirVersions.STU3])
-    .isRequired,
+  fhirVersion: PropTypes.oneOf([
+    fhirVersions.DSTU2,
+    fhirVersions.STU3,
+    fhirVersions.R4,
+  ]).isRequired,
 };
 
 export default MedicationDispense;

--- a/src/components/resources/MedicationDispense/MedicationDispense.stories.js
+++ b/src/components/resources/MedicationDispense/MedicationDispense.stories.js
@@ -8,6 +8,8 @@ import dstu2Example1 from '../../../fixtures/dstu2/resources/medicationDispense/
 import dstu2Example2 from '../../../fixtures/dstu2/resources/medicationDispense/example2.json';
 import stu3Example1 from '../../../fixtures/stu3/resources/medicationDispense/example1.json';
 import stu3Example2 from '../../../fixtures/stu3/resources/medicationDispense/example2.json';
+import R4Example1 from '../../../fixtures/r4/resources/medicationDispense/example1.json';
+import R4Example2 from '../../../fixtures/r4/resources/medicationDispense/example2.json';
 
 export default {
   title: 'MedicationDispense',
@@ -49,6 +51,26 @@ export const Example2OfSTU3 = () => {
     <MedicationDispense
       fhirResource={fhirResource}
       fhirVersion={fhirVersions.STU3}
+    />
+  );
+};
+
+export const Example1OfR4 = () => {
+  const fhirResource = object('Resource', R4Example1);
+  return (
+    <MedicationDispense
+      fhirResource={fhirResource}
+      fhirVersion={fhirVersions.R4}
+    />
+  );
+};
+
+export const Example2OfR4 = () => {
+  const fhirResource = object('Resource', R4Example2);
+  return (
+    <MedicationDispense
+      fhirResource={fhirResource}
+      fhirVersion={fhirVersions.R4}
     />
   );
 };

--- a/src/components/resources/MedicationDispense/MedicationDispense.test.js
+++ b/src/components/resources/MedicationDispense/MedicationDispense.test.js
@@ -33,13 +33,13 @@ describe('should render Device component properly', () => {
       fhirVersion: fhirVersions.STU3,
     };
 
-    const { container, getByTestId, queryAllByTestId } = render(
+    const { container, getByTestId, queryByTestId } = render(
       <MedicationDispense {...defaultProps} />,
     );
     expect(container).not.toBeNull();
 
     expect(getByTestId('title').textContent).toContain('Capecitabine');
-    expect(queryAllByTestId('whenPrepared').length).toEqual(0);
+    expect(queryByTestId('whenPrepared')).toBeNull();
     expect(getByTestId('medicationCoding').textContent).toContain(
       'Capecitabine 500mg oral tablet',
     );

--- a/src/fixtures/r4/resources/medicationDispense/example1.json
+++ b/src/fixtures/r4/resources/medicationDispense/example1.json
@@ -1,0 +1,83 @@
+{
+  "resourceType": "MedicationDispense",
+  "id": "meddisp008",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: meddisp008</p><p><b>contained</b>: </p><p><b>status</b>: completed</p><p><b>medication</b>: id: medexample015; Capecitabine 500mg oral tablet (Xeloda) <span>(Details : {RxNorm code '213293' = 'Xeloda 500 MG Oral Tablet', given as 'Capecitabine 500mg oral tablet (Xeloda)'})</span></p><p><b>subject</b>: <a>Donald Duck</a></p><h3>Performers</h3><table><tr><td>-</td><td><b>Actor</b></td></tr><tr><td>*</td><td><a>Practitioner/f006</a></td></tr></table><p><b>authorizingPrescription</b>: <a>MedicationRequest/medrx0309</a></p><p><b>dosageInstruction</b>: </p></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "medexample015",
+      "code": {
+        "coding": [
+          {
+            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+            "code": "213293",
+            "display": "Capecitabine 500mg oral tablet (Xeloda)"
+          }
+        ]
+      }
+    }
+  ],
+  "status": "completed",
+  "medicationReference": {
+    "reference": "#medexample015"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "performer": [
+    {
+      "actor": {
+        "reference": "Practitioner/f006"
+      }
+    }
+  ],
+  "authorizingPrescription": [
+    {
+      "reference": "MedicationRequest/medrx0309"
+    }
+  ],
+  "dosageInstruction": [
+    {
+      "sequence": 1,
+      "timing": {
+        "repeat": {
+          "frequency": 2,
+          "period": 21,
+          "periodUnit": "d"
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "394899003",
+            "display": "oral administration of treatment"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "ordered",
+                "display": "Ordered"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 500,
+            "unit": "mg",
+            "system": "http://unitsofmeasure.org",
+            "code": "mg"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/fixtures/r4/resources/medicationDispense/example2.json
+++ b/src/fixtures/r4/resources/medicationDispense/example2.json
@@ -1,0 +1,220 @@
+{
+  "resourceType": "MedicationDispense",
+  "id": "meddisp0302",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: meddisp0302</p><p><b>contained</b>: </p><p><b>status</b>: in-progress</p><p><b>medication</b>: Novolog 100u/ml. Generated Summary: id: med0360; Novolog 100u/ml <span>(Details : {http://hl7.org/fhir/sid/ndc code '0169-7501-11' = 'n/a', given as 'Novolog 100u/ml'})</span>; Injection solution (qualifier value) <span>(Details : {SNOMED CT code '385219001' = 'Injection solution', given as 'Injection solution (qualifier value)'})</span></p><p><b>subject</b>: <a>Donald Duck</a></p><h3>Performers</h3><table><tr><td>-</td><td><b>Function</b></td><td><b>Actor</b></td></tr><tr><td>*</td><td>Final Checker <span>(Details : {http://terminology.hl7.org/CodeSystem/medicationdispense-performer-function code 'finalchecker' = 'Final Checker', given as 'Final Checker'})</span></td><td><a>Practitioner/f006</a></td></tr></table><p><b>authorizingPrescription</b>: <a>MedicationRequest/medrx0321</a></p><p><b>type</b>: Refill - Part Fill <span>(Details : {http://terminology.hl7.org/CodeSystem/v3-ActCode code 'RFP' = 'Refill - Part Fill', given as 'Refill - Part Fill'})</span></p><p><b>quantity</b>: 10 ml<span> (Details: UCUM code ml = 'ml')</span></p><p><b>daysSupply</b>: 30 Day<span> (Details: UCUM code d = 'd')</span></p><p><b>whenPrepared</b>: 15/01/2015 10:20:00 AM</p><p><b>whenHandedOver</b>: 15/01/2015 4:20:00 PM</p><p><b>dosageInstruction</b>: , , </p></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "med0360",
+      "code": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/sid/ndc",
+            "code": "0169-7501-11",
+            "display": "Novolog 100u/ml"
+          }
+        ]
+      },
+      "form": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "385219001",
+            "display": "Injection solution (qualifier value)"
+          }
+        ]
+      },
+      "ingredient": [
+        {
+          "itemCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "325072002",
+                "display": "Insulin Aspart (substance)"
+              }
+            ]
+          },
+          "strength": {
+            "numerator": {
+              "value": 100,
+              "system": "http://unitsofmeasure.org",
+              "code": "U"
+            },
+            "denominator": {
+              "value": 1,
+              "system": "http://unitsofmeasure.org",
+              "code": "mL"
+            }
+          }
+        }
+      ],
+      "batch": {
+        "lotNumber": "12345",
+        "expirationDate": "2019-10-31"
+      }
+    }
+  ],
+  "status": "in-progress",
+  "medicationReference": {
+    "reference": "#med0360",
+    "display": "Novolog 100u/ml"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "performer": [
+    {
+      "function": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/medicationdispense-performer-function",
+            "code": "finalchecker",
+            "display": "Final Checker"
+          }
+        ]
+      },
+      "actor": {
+        "reference": "Practitioner/f006"
+      }
+    }
+  ],
+  "authorizingPrescription": [
+    {
+      "reference": "MedicationRequest/medrx0321"
+    }
+  ],
+  "type": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "RFP",
+        "display": "Refill - Part Fill"
+      }
+    ]
+  },
+  "quantity": {
+    "value": 10,
+    "system": "http://unitsofmeasure.org",
+    "code": "ml"
+  },
+  "daysSupply": {
+    "value": 30,
+    "unit": "Day",
+    "system": "http://unitsofmeasure.org",
+    "code": "d"
+  },
+  "whenPrepared": "2015-01-15T10:20:00Z",
+  "whenHandedOver": "2015-01-15T16:20:00Z",
+  "dosageInstruction": [
+    {
+      "sequence": 1,
+      "text": "Before Breakfast",
+      "additionalInstruction": [
+        {
+          "text": "Check sugar level before taking Novolog"
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "ordered",
+                "display": "Ordered"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 10,
+            "unit": "U",
+            "system": "http://unitsofmeasure.org",
+            "code": "U"
+          }
+        }
+      ]
+    },
+    {
+      "sequence": 1,
+      "text": "15 units before lunch",
+      "additionalInstruction": [
+        {
+          "text": "Check sugar level before taking Novolog"
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "ordered",
+                "display": "Ordered"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 15,
+            "unit": "U",
+            "system": "http://unitsofmeasure.org",
+            "code": "U"
+          }
+        }
+      ]
+    },
+    {
+      "sequence": 1,
+      "text": "20 units before dinner",
+      "additionalInstruction": [
+        {
+          "text": "Check sugar level before taking Novolog"
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "ordered",
+                "display": "Ordered"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 20,
+            "unit": "U",
+            "system": "http://unitsofmeasure.org",
+            "code": "U"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
issue: #122 

DONE:
 - add R4 support to component (add tests, stories and examples of R4 resource data)

<img width="1292" alt="Screenshot 2020-02-12 at 17 37 25" src="https://user-images.githubusercontent.com/6116778/74356428-99f02a80-4dbe-11ea-9752-f27eed86301c.png">
