### PR TITLE
Add R4 support to Device component

### DIFF
--- a/src/components/resources/Device/Device.js
+++ b/src/components/resources/Device/Device.js
@@ -131,7 +131,7 @@ const Device = props => {
     <Root name="Device">
       <Header>
         {model && <Title>{model}</Title>}
-        {status && <Badge>{status}</Badge>}
+        {status && <Badge data-testid="status">{status}</Badge>}
         {hasExpiry && (
           <BadgeSecondary data-testid="expiry">
             expires on <Date fhirData={getExpiry} />
@@ -146,7 +146,7 @@ const Device = props => {
             ))}
           </Value>
         )}
-        <Value label="Unique device identifier">
+        <Value label="Unique device identifier" data-testid="uniqueId">
           {getUdi ? getUdi : <MissingValue />}
         </Value>
         {udiCarrierAIDC && <Value label="AIDC barcode">{udiCarrierAIDC}</Value>}

--- a/src/components/resources/Device/Device.js
+++ b/src/components/resources/Device/Device.js
@@ -4,6 +4,7 @@ import _get from 'lodash/get';
 import _has from 'lodash/has';
 
 import Coding from '../../datatypes/Coding';
+import CodeableConcept, { hasValue } from '../../datatypes/CodeableConcept';
 import Date from '../../datatypes/Date';
 import fhirVersions from '../fhirResourceVersions';
 import UnhandledResourceDataStructure from '../UnhandledResourceDataStructure';
@@ -15,10 +16,11 @@ import {
   BadgeSecondary,
   Body,
   Value,
+  MissingValue,
 } from '../../ui';
 
 const commonDTO = fhirResource => {
-  const model = _get(fhirResource, 'model', '');
+  const model = _get(fhirResource, 'model', 'Device');
   const status = _get(fhirResource, 'status', '');
   const getTypeCoding = _get(fhirResource, 'type.coding');
   const hasTypeCoding = Array.isArray(getTypeCoding);
@@ -45,10 +47,32 @@ const stu3DTO = fhirResource => {
   const getUdi = _get(fhirResource, 'udi.name');
   const hasExpiry = _has(fhirResource, 'expirationDate');
   const getExpiry = _get(fhirResource, 'expirationDate');
+  const safety =
+    _get(fhirResource, 'safety[0]') || _get(fhirResource, 'safety');
   return {
     getUdi,
     hasExpiry,
     getExpiry,
+    safety,
+  };
+};
+
+const r4DTO = fhirResource => {
+  const getUdi = _get(fhirResource, 'udiCarrier.deviceIdentifier');
+  const hasExpiry = _has(fhirResource, 'expirationDate');
+  const getExpiry = _get(fhirResource, 'expirationDate');
+  const udiCarrierAIDC = _get(fhirResource, 'udiCarrier.carrierAIDC');
+  const udiCarrierHRF = _get(fhirResource, 'udiCarrier.carrierHRF');
+  const safety = _get(fhirResource, 'safety', []);
+  const hasSafety = hasValue(safety);
+  return {
+    getUdi,
+    hasExpiry,
+    getExpiry,
+    udiCarrierAIDC,
+    udiCarrierHRF,
+    safety,
+    hasSafety,
   };
 };
 
@@ -64,6 +88,12 @@ const resourceDTO = (fhirVersion, fhirResource) => {
       return {
         ...commonDTO(fhirResource),
         ...stu3DTO(fhirResource),
+      };
+    }
+    case fhirVersions.R4: {
+      return {
+        ...commonDTO(fhirResource),
+        ...r4DTO(fhirResource),
       };
     }
 
@@ -90,8 +120,13 @@ const Device = props => {
     getTypeCoding,
     hasTypeCoding,
     getUdi,
+    udiCarrierAIDC,
+    udiCarrierHRF,
+    safety,
+    hasSafety,
   } = fhirResourceData;
 
+  const safetyArr = hasSafety && !Array.isArray(safety) ? [safety] : safety;
   return (
     <Root name="Device">
       <Header>
@@ -111,7 +146,17 @@ const Device = props => {
             ))}
           </Value>
         )}
-        {getUdi && <Value label="Unique device identifier">{getUdi}</Value>}
+        <Value label="Unique device identifier">
+          {getUdi ? getUdi : <MissingValue />}
+        </Value>
+        {udiCarrierAIDC && <Value label="AIDC barcode">{udiCarrierAIDC}</Value>}
+        {udiCarrierHRF && <Value label="HRF barcode">{udiCarrierHRF}</Value>}
+        {hasSafety &&
+          safetyArr.map((item, i) => (
+            <Value label="HRF barcode" key={`safety-${i}`}>
+              <CodeableConcept fhirData={item} />
+            </Value>
+          ))}
       </Body>
     </Root>
   );
@@ -119,8 +164,11 @@ const Device = props => {
 
 Device.propTypes = {
   fhirResource: PropTypes.shape({}).isRequired,
-  fhirVersion: PropTypes.oneOf([fhirVersions.DSTU2, fhirVersions.STU3])
-    .isRequired,
+  fhirVersion: PropTypes.oneOf([
+    fhirVersions.DSTU2,
+    fhirVersions.STU3,
+    fhirVersions.R4,
+  ]).isRequired,
 };
 
 export default Device;

--- a/src/components/resources/Device/Device.js
+++ b/src/components/resources/Device/Device.js
@@ -47,13 +47,14 @@ const stu3DTO = fhirResource => {
   const getUdi = _get(fhirResource, 'udi.name');
   const hasExpiry = _has(fhirResource, 'expirationDate');
   const getExpiry = _get(fhirResource, 'expirationDate');
-  const safety =
-    _get(fhirResource, 'safety[0]') || _get(fhirResource, 'safety');
+  const safety = _get(fhirResource, 'safety', []);
+  const hasSafety = hasValue(safety);
   return {
     getUdi,
     hasExpiry,
     getExpiry,
     safety,
+    hasSafety,
   };
 };
 

--- a/src/components/resources/Device/Device.stories.js
+++ b/src/components/resources/Device/Device.stories.js
@@ -7,6 +7,8 @@ import dstu2Example1 from '../../../fixtures/dstu2/resources/device/example.json
 import dstu2Example2 from '../../../fixtures/dstu2/resources/device/example2.json';
 import stu3Example1 from '../../../fixtures/stu3/resources/device/example1.json';
 import stu3Example2 from '../../../fixtures/stu3/resources/device/example2.json';
+import r4Example1 from '../../../fixtures/r4/resources/device/example1.json';
+import r4Example2 from '../../../fixtures/r4/resources/device/example2.json';
 import fhirVersions from '../fhirResourceVersions';
 
 export default {
@@ -34,6 +36,16 @@ export const Example1OfSTU3 = () => {
 export const Example2OfSTU3 = () => {
   const fhirResource = object('Resource', stu3Example2);
   return <Device fhirResource={fhirResource} fhirVersion={fhirVersions.STU3} />;
+};
+
+export const Example1OfR4 = () => {
+  const fhirResource = object('Resource', r4Example1);
+  return <Device fhirResource={fhirResource} fhirVersion={fhirVersions.R4} />;
+};
+
+export const Example2OfR4 = () => {
+  const fhirResource = object('Resource', r4Example2);
+  return <Device fhirResource={fhirResource} fhirVersion={fhirVersions.R4} />;
 };
 
 export const ExampleWithoutFHIRVersionProperty = () => {

--- a/src/components/resources/Device/Device.test.js
+++ b/src/components/resources/Device/Device.test.js
@@ -5,6 +5,7 @@ import Device from './Device';
 import fhirVersions from '../fhirResourceVersions';
 import dstu2Example1 from '../../../fixtures/dstu2/resources/device/example.json';
 import stu3Example2 from '../../../fixtures/stu3/resources/device/example2.json';
+import r4Example2 from '../../../fixtures/r4/resources/device/example2.json';
 
 describe('should render Device component properly', () => {
   it('should render with DSTU2 source data', () => {
@@ -21,6 +22,8 @@ describe('should render Device component properly', () => {
     expect(getByTestId('expiry').textContent).toContain('expires');
 
     expect(getByTestId('typeCoding').textContent).toContain('Drain');
+
+    expect(getByTestId('uniqueId').textContent).toEqual('-');
   });
 
   it('should render with STU3 source data', () => {
@@ -37,5 +40,29 @@ describe('should render Device component properly', () => {
     expect(getByTestId('expiry').textContent).toContain('expires');
 
     expect(getByTestId('typeCoding').textContent).toContain('Coated');
+
+    expect(getByTestId('uniqueId').textContent).toEqual('FHIR® Hip System');
+  });
+
+  it('should render with R4 source data', () => {
+    const defaultProps = {
+      fhirResource: r4Example2,
+      fhirVersion: fhirVersions.R4,
+    };
+
+    const { container, getByTestId, queryByTestId } = render(
+      <Device {...defaultProps} />,
+    );
+    expect(container).not.toBeNull();
+
+    expect(getByTestId('title').textContent).toEqual('Device');
+
+    expect(getByTestId('status').textContent).toEqual('active');
+
+    expect(queryByTestId('expiry')).toBeNull();
+
+    expect(queryByTestId('typeCoding')).toBeNull();
+
+    expect(getByTestId('uniqueId').textContent).toEqual('-');
   });
 });

--- a/src/fixtures/r4/resources/device/example1.json
+++ b/src/fixtures/r4/resources/device/example1.json
@@ -1,0 +1,14 @@
+{
+  "resourceType": "Device",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example</p><p><b>identifier</b>: 345675</p></div>"
+  },
+  "identifier": [
+    {
+      "system": "http://goodcare.org/devices/id",
+      "value": "345675"
+    }
+  ]
+}

--- a/src/fixtures/r4/resources/device/example2.json
+++ b/src/fixtures/r4/resources/device/example2.json
@@ -1,0 +1,15 @@
+{
+  "resourceType": "Device",
+  "id": "f001",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: f001</p><p><b>identifier</b>: 12345</p><p><b>status</b>: active</p></div>"
+  },
+  "identifier": [
+    {
+      "system": "http:/goodhealthhospital/identifier/devices",
+      "value": "12345"
+    }
+  ],
+  "status": "active"
+}


### PR DESCRIPTION
issue: #132 

This Component didn't have example data with more fields filled out, so it doesn't render any particular info on the screenshot.
Examples taken from: http://hl7.org/fhir/device-examples.html
It will be best to add more test data from other sources for R4 version.

DONE:

Add R4 support to component
Add fixtures, tests, storybook stories

![image](https://user-images.githubusercontent.com/60238331/74747957-0c9e5180-5268-11ea-8ffc-24c6bb173b9a.png)