### PR TITLE
Add R4 support to MedicationAdministration component

### DIFF
--- a/src/components/resources/MedicationAdministration/MedicationAdministration.js
+++ b/src/components/resources/MedicationAdministration/MedicationAdministration.js
@@ -67,6 +67,23 @@ const stu3DTO = fhirResource => {
   };
 };
 
+const r4DTO = fhirResource => {
+  const subject = _get(fhirResource, 'subject');
+  const periodTimeStart = _get(fhirResource, 'effectivePeriod.start');
+  const periodTimeEnd = _get(fhirResource, 'effectivePeriod.end');
+  const practitioner = _get(fhirResource, 'performer.0.actor');
+  const dosageQuantityVal = _get(fhirResource, 'dosage.dose.value', '');
+  const dosageQuantityUnit = _get(fhirResource, 'dosage.dose.unit', '');
+  const dosageQuantity = `${dosageQuantityVal} ${dosageQuantityUnit}`.trim();
+  return {
+    subject,
+    practitioner,
+    periodTimeStart,
+    periodTimeEnd,
+    dosageQuantity,
+  };
+};
+
 const resourceDTO = (fhirVersion, fhirResource) => {
   switch (fhirVersion) {
     case fhirVersions.DSTU2: {
@@ -79,6 +96,12 @@ const resourceDTO = (fhirVersion, fhirResource) => {
       return {
         ...commonDTO(fhirResource),
         ...stu3DTO(fhirResource),
+      };
+    }
+    case fhirVersions.R4: {
+      return {
+        ...commonDTO(fhirResource),
+        ...r4DTO(fhirResource),
       };
     }
 
@@ -171,8 +194,11 @@ const MedicationAdministration = props => {
 
 MedicationAdministration.propTypes = {
   fhirResource: PropTypes.shape({}).isRequired,
-  fhirVersion: PropTypes.oneOf([fhirVersions.DSTU2, fhirVersions.STU3])
-    .isRequired,
+  fhirVersion: PropTypes.oneOf([
+    fhirVersions.DSTU2,
+    fhirVersions.STU3,
+    fhirVersions.R4,
+  ]).isRequired,
 };
 
 export default MedicationAdministration;

--- a/src/components/resources/MedicationAdministration/MedicationAdministration.stories.js
+++ b/src/components/resources/MedicationAdministration/MedicationAdministration.stories.js
@@ -5,6 +5,9 @@ import MedicationAdministration from './MedicationAdministration';
 
 import dstu2Example1 from '../../../fixtures/dstu2/resources/medicationAdministration/example1.json';
 import stu3Example1 from '../../../fixtures/stu3/resources/medicationAdministration/example1.json';
+import r4Example1 from '../../../fixtures/r4/resources/medicationAdministration/example1.json';
+import r4Example2 from '../../../fixtures/r4/resources/medicationAdministration/example2.json';
+import r4Example3 from '../../../fixtures/r4/resources/medicationAdministration/example3.json';
 import fhirVersions from '../fhirResourceVersions';
 
 export default {
@@ -26,6 +29,36 @@ export const ExampleOfSTU3 = () => {
   return (
     <MedicationAdministration
       fhirVersion={fhirVersions.STU3}
+      fhirResource={fhirResource}
+    />
+  );
+};
+
+export const Example1OfR4 = () => {
+  const fhirResource = object('Resource', r4Example1);
+  return (
+    <MedicationAdministration
+      fhirVersion={fhirVersions.R4}
+      fhirResource={fhirResource}
+    />
+  );
+};
+
+export const Example2OfR4 = () => {
+  const fhirResource = object('Resource', r4Example2);
+  return (
+    <MedicationAdministration
+      fhirVersion={fhirVersions.R4}
+      fhirResource={fhirResource}
+    />
+  );
+};
+
+export const Example3OfR4 = () => {
+  const fhirResource = object('Resource', r4Example3);
+  return (
+    <MedicationAdministration
+      fhirVersion={fhirVersions.R4}
       fhirResource={fhirResource}
     />
   );

--- a/src/components/resources/MedicationAdministration/MedicationAdministration.test.js
+++ b/src/components/resources/MedicationAdministration/MedicationAdministration.test.js
@@ -5,6 +5,8 @@ import MedicationAdministration from './MedicationAdministration';
 import fhirVersions from '../fhirResourceVersions';
 import dstu2Example1 from '../../../fixtures/dstu2/resources/medicationAdministration/example1.json';
 import stu3Example1 from '../../../fixtures/stu3/resources/medicationAdministration/example1.json';
+import r4Example1 from '../../../fixtures/r4/resources/medicationAdministration/example1.json';
+import r4Example2 from '../../../fixtures/r4/resources/medicationAdministration/example3.json';
 
 describe('should render MedicationAdministration component properly', () => {
   it('should render with DSTU2 source data', () => {
@@ -65,5 +67,45 @@ describe('should render MedicationAdministration component properly', () => {
     );
 
     expect(getByTestId('dosageQuantity').textContent).toEqual('500 mg');
+  });
+
+  it('should render with R4 source data', () => {
+    const defaultProps = {
+      fhirResource: r4Example1,
+      fhirVersion: fhirVersions.R4,
+    };
+
+    const { container, getByTestId, queryByTestId } = render(
+      <MedicationAdministration {...defaultProps} />,
+    );
+    expect(container).not.toBeNull();
+    expect(getByTestId('title').textContent).toContain('#med0303');
+    expect(getByTestId('status').textContent).toContain('on-hold');
+    expect(getByTestId('patient').textContent).toContain('Donald Duck');
+    expect(queryByTestId('practitioner')).toBeNull();
+    expect(getByTestId('periodTimeStart').textContent).toEqual('2015-01-15');
+    expect(getByTestId('periodTimeEnd').textContent).toEqual('2015-01-15');
+    expect(getByTestId('dosageRoute').textContent).toContain('-');
+    expect(getByTestId('dosageQuantity').textContent).toEqual('-');
+  });
+
+  it('should render with R4 source data - example 2', () => {
+    const defaultProps = {
+      fhirResource: r4Example2,
+      fhirVersion: fhirVersions.R4,
+    };
+
+    const { container, getByTestId } = render(
+      <MedicationAdministration {...defaultProps} />,
+    );
+    expect(container).not.toBeNull();
+    expect(getByTestId('title').textContent).toContain('#med0306');
+    expect(getByTestId('status').textContent).toContain('completed');
+    expect(getByTestId('patient').textContent).toContain('Donald Duck');
+    expect(getByTestId('practitioner').textContent).toContain('Patrick Pump');
+    expect(getByTestId('periodTimeStart').textContent).toEqual('2015-01-15');
+    expect(getByTestId('periodTimeEnd').textContent).toEqual('2015-01-15');
+    expect(getByTestId('dosageRoute').textContent).toContain('Oral Route');
+    expect(getByTestId('dosageQuantity').textContent).toEqual('2 TAB');
   });
 });

--- a/src/fixtures/r4/resources/medicationAdministration/example1.json
+++ b/src/fixtures/r4/resources/medicationAdministration/example1.json
@@ -1,0 +1,62 @@
+{
+  "resourceType": "MedicationAdministration",
+  "id": "medadminexample03",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: medadminexample03</p><p><b>contained</b>: </p><p><b>status</b>: on-hold</p><p><b>statusReason</b>: Administration of medication not done due to a contraindication (situation) <span>(Details : {SNOMED CT code '373147003' = 'Medication not administered because contraindicated', given as 'Administration of medication not done due to a contraindication (situation)'})</span></p><p><b>medication</b>: id: med0303; Alemtuzumab 10mg/ml (Lemtrada) <span>(Details : {RxNorm code '1594660' = 'alemtuzumab 10 MG/ML [Lemtrada]', given as 'Alemtuzumab 10mg/ml (Lemtrada)'})</span></p><p><b>subject</b>: <a>Donald Duck</a></p><p><b>context</b>: <a>Encounter/f001</a></p><p><b>supportingInformation</b>: <a>Condition/f204</a></p><p><b>effective</b>: 15/01/2015 2:30:00 PM --&gt; 15/01/2015 2:30:00 PM</p><p><b>request</b>: <a>MedicationRequest/medrx0317</a></p><p><b>note</b>: Patient started Bupropion this morning - will administer in a reduced dose tomorrow</p></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "med0303",
+      "code": {
+        "coding": [
+          {
+            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+            "code": "1594660",
+            "display": "Alemtuzumab 10mg/ml (Lemtrada)"
+          }
+        ]
+      }
+    }
+  ],
+  "status": "on-hold",
+  "statusReason": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "373147003",
+          "display": "Administration of medication not done due to a contraindication (situation)"
+        }
+      ]
+    }
+  ],
+  "medicationReference": {
+    "reference": "#med0303"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "context": {
+    "reference": "Encounter/f001"
+  },
+  "supportingInformation": [
+    {
+      "reference": "Condition/f204"
+    }
+  ],
+  "effectivePeriod": {
+    "start": "2015-01-15T14:30:00+01:00",
+    "end": "2015-01-15T14:30:00+01:00"
+  },
+  "request": {
+    "reference": "MedicationRequest/medrx0317"
+  },
+  "note": [
+    {
+      "text": "Patient started Bupropion this morning - will administer in a reduced dose tomorrow"
+    }
+  ]
+}

--- a/src/fixtures/r4/resources/medicationAdministration/example2.json
+++ b/src/fixtures/r4/resources/medicationAdministration/example2.json
@@ -1,0 +1,134 @@
+{
+  "resourceType": "MedicationAdministration",
+  "id": "medadmin0301",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: medadmin0301</p><p><b>contained</b>: , </p><p><b>status</b>: in-progress</p><p><b>medication</b>: id: med0301; Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE) <span>(Details : {http://hl7.org/fhir/sid/ndc code '0069-2587-10' = 'n/a', given as 'Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE)'})</span></p><p><b>subject</b>: <a>Donald Duck</a></p><p><b>context</b>: <a>encounter who leads to this prescription</a></p><p><b>effective</b>: 15/01/2015 2:30:00 PM --&gt; (ongoing)</p><h3>Performers</h3><table><tr><td>-</td><td><b>Actor</b></td></tr><tr><td>*</td><td><a>Patrick Pump</a></td></tr></table><p><b>reasonCode</b>: Given as Ordered <span>(Details : {http://terminology.hl7.org/CodeSystem/reason-medication-given code 'b' = 'Given as Ordered', given as 'Given as Ordered'})</span></p><p><b>request</b>: <a>MedicationRequest/medrx0318</a></p><h3>Dosages</h3><table><tr><td>-</td><td><b>Text</b></td><td><b>Route</b></td><td><b>Method</b></td><td><b>Dose</b></td></tr><tr><td>*</td><td>500mg IV q6h x 3 days</td><td>Intravenous route (qualifier value) <span>(Details : {SNOMED CT code '47625008' = 'Intravenous route', given as 'Intravenous route (qualifier value)'})</span></td><td>IV Push <span>(Details )</span></td><td>500 mg<span> (Details: UCUM code mg = 'mg')</span></td></tr></table><p><b>eventHistory</b>: Author's Signature. Generated Summary: id: signature; recorded: 01/02/2017 5:23:07 PM; </p></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "med0301",
+      "code": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/sid/ndc",
+            "code": "0069-2587-10",
+            "display": "Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE)"
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": "Provenance",
+      "id": "signature",
+      "target": [
+        {
+          "reference": "ServiceRequest/physiotherapy"
+        }
+      ],
+      "recorded": "2017-02-01T17:23:07Z",
+      "agent": [
+        {
+          "role": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "AUT"
+                }
+              ]
+            }
+          ],
+          "who": {
+            "reference": "Practitioner/example",
+            "display": "Dr Adam Careful"
+          }
+        }
+      ],
+      "signature": [
+        {
+          "type": [
+            {
+              "system": "urn:iso-astm:E1762-95:2013",
+              "code": "1.2.840.10065.1.12.1.1",
+              "display": "Author's Signature"
+            }
+          ],
+          "when": "2017-02-01T17:23:07Z",
+          "who": {
+            "reference": "Practitioner/example",
+            "display": "Dr Adam Careful"
+          },
+          "targetFormat": "application/fhir+xml",
+          "sigFormat": "application/signature+xml",
+          "data": "dGhpcyBibG9iIGlzIHNuaXBwZWQ="
+        }
+      ]
+    }
+  ],
+  "status": "in-progress",
+  "medicationReference": {
+    "reference": "#med0301"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "context": {
+    "reference": "Encounter/f001",
+    "display": "encounter who leads to this prescription"
+  },
+  "effectivePeriod": {
+    "start": "2015-01-15T14:30:00+01:00"
+  },
+  "performer": [
+    {
+      "actor": {
+        "reference": "Practitioner/f007",
+        "display": "Patrick Pump"
+      }
+    }
+  ],
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/reason-medication-given",
+          "code": "b",
+          "display": "Given as Ordered"
+        }
+      ]
+    }
+  ],
+  "request": {
+    "reference": "MedicationRequest/medrx0318"
+  },
+  "dosage": {
+    "text": "500mg IV q6h x 3 days",
+    "route": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "47625008",
+          "display": "Intravenous route (qualifier value)"
+        }
+      ]
+    },
+    "method": {
+      "text": "IV Push"
+    },
+    "dose": {
+      "value": 500,
+      "unit": "mg",
+      "system": "http://unitsofmeasure.org",
+      "code": "mg"
+    }
+  },
+  "eventHistory": [
+    {
+      "reference": "#signature",
+      "display": "Author's Signature"
+    }
+  ]
+}

--- a/src/fixtures/r4/resources/medicationAdministration/example3.json
+++ b/src/fixtures/r4/resources/medicationAdministration/example3.json
@@ -1,0 +1,86 @@
+{
+  "resourceType": "MedicationAdministration",
+  "id": "medadmin0306",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: medadmin0306</p><p><b>contained</b>: </p><p><b>status</b>: completed</p><p><b>medication</b>: id: med0306; Azithromycin 250mg capsule (product) <span>(Details : {SNOMED CT code '324252006' = 'Azithromycin 250mg capsule', given as 'Azithromycin 250mg capsule (product)'})</span></p><p><b>subject</b>: <a>Donald Duck</a></p><p><b>context</b>: <a>encounter who leads to this prescription</a></p><p><b>effective</b>: 15/01/2015 4:30:00 AM --&gt; 15/01/2015 2:30:00 PM</p><h3>Performers</h3><table><tr><td>-</td><td><b>Function</b></td><td><b>Actor</b></td></tr><tr><td>*</td><td>Performer <span>(Details : {http://terminology.hl7.org/CodeSystem/med-admin-perform-function code 'performer' = 'Performer', given as 'Performer'})</span></td><td><a>Patrick Pump</a></td></tr></table><p><b>request</b>: <a>MedicationRequest/medrx0302</a></p><h3>Dosages</h3><table><tr><td>-</td><td><b>Text</b></td><td><b>Route</b></td><td><b>Method</b></td><td><b>Dose</b></td></tr><tr><td>*</td><td>Two tablets at once</td><td>Oral Route <span>(Details : {SNOMED CT code '26643006' = 'Oral route', given as 'Oral Route'})</span></td><td>Swallow - dosing instruction imperative (qualifier value) <span>(Details : {SNOMED CT code '421521009' = 'Swallow', given as 'Swallow - dosing instruction imperative (qualifier value)'})</span></td><td>2 TAB<span> (Details: http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm code TAB = 'Tablet')</span></td></tr></table></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "med0306",
+      "code": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "324252006",
+            "display": "Azithromycin 250mg capsule (product)"
+          }
+        ]
+      }
+    }
+  ],
+  "status": "completed",
+  "medicationReference": {
+    "reference": "#med0306"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "context": {
+    "reference": "Encounter/f001",
+    "display": "encounter who leads to this prescription"
+  },
+  "effectivePeriod": {
+    "start": "2015-01-15T04:30:00+01:00",
+    "end": "2015-01-15T14:30:00+01:00"
+  },
+  "performer": [
+    {
+      "function": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/med-admin-perform-function",
+            "code": "performer",
+            "display": "Performer"
+          }
+        ]
+      },
+      "actor": {
+        "reference": "Practitioner/f007",
+        "display": "Patrick Pump"
+      }
+    }
+  ],
+  "request": {
+    "reference": "MedicationRequest/medrx0302"
+  },
+  "dosage": {
+    "text": "Two tablets at once",
+    "route": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "26643006",
+          "display": "Oral Route"
+        }
+      ]
+    },
+    "method": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "421521009",
+          "display": "Swallow - dosing instruction imperative (qualifier value)"
+        }
+      ]
+    },
+    "dose": {
+      "value": 2,
+      "unit": "TAB",
+      "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+      "code": "TAB"
+    }
+  }
+}


### PR DESCRIPTION
issue: #137 

DONE:

Add R4 support to component
Add fixtures, tests, storybook stories

![image](https://user-images.githubusercontent.com/60238331/75141719-de01fa00-56f1-11ea-958f-c9daec42363d.png)