### PR TITLE
fix issues related to styles of resources components 

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,7 @@
 import { configure, addParameters, addDecorator } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
 
+import '../src/components/ui/bootstrap-reboot.min.css';
 import '../src/style.css';
 
 addParameters({

--- a/package-lock.json
+++ b/package-lock.json
@@ -6594,6 +6594,81 @@
         "toggle-selection": "^1.0.6"
       }
     },
+    "copy-webpack-plugin": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
+      "integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
+      "dev": true,
+      "requires": {
+        "cacache": "^12.0.3",
+        "find-cache-dir": "^2.1.0",
+        "glob-parent": "^3.1.0",
+        "globby": "^7.1.1",
+        "is-glob": "^4.0.1",
+        "loader-utils": "^1.2.3",
+        "minimatch": "^3.0.4",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^2.1.2",
+        "webpack-log": "^2.0.0"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "serialize-javascript": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+          "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        }
+      }
+    },
     "core-js": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-transform-imports": "^2.0.0",
+    "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.4.2",
     "dedent": "^0.7.0",
     "eslint": "^6.7.2",

--- a/src/components/containers/CodeBlock/CodeBlock.css
+++ b/src/components/containers/CodeBlock/CodeBlock.css
@@ -1,5 +1,4 @@
 .fhir-container__CodeBlock {
-  width: 100%;
   padding: 1.5rem;
   color: #f8f9fa;
   background-color: #343a40;
@@ -7,4 +6,5 @@
   word-break: break-word;
   font-family: monospace;
   font-size: 16px;
+  overflow-x: scroll;
 }

--- a/src/components/containers/ResourceContainer/ResourceContainer.css
+++ b/src/components/containers/ResourceContainer/ResourceContainer.css
@@ -17,8 +17,8 @@
 
 .fhir-container__ResourceContainer__json-button-wrapper {
   position: absolute;
-  right: 1rem;
-  top: 1rem;
+  right: 2rem;
+  top: 0.5rem;
 }
 
 .fhir-container__ResourceContainer__json--visible {
@@ -34,16 +34,15 @@
   color: #6c757d;
   border-color: #6c757d;
   cursor: pointer;
-  padding: 0.25rem 0.5rem;
+  padding: 0.15rem 0.5rem;
   font-size: 0.875rem;
-  line-height: 1.5;
+  line-height: 1rem;
   border-radius: 0.2rem;
   display: inline-block;
   font-weight: 400;
   text-align: center;
   vertical-align: middle;
   user-select: none;
-  background-color: transparent;
   border: 1px solid #6c6c6c;
   transition: all 0.15s ease-in-out;
 }
@@ -52,4 +51,10 @@
   color: #fff;
   background-color: #6c757d;
   border-color: #6c757d;
+}
+
+.fhir-container__ResourceContainer__json-button-fhir-version {
+  font-size: 0.7rem;
+  color: red;
+  text-transform: uppercase;
 }

--- a/src/components/containers/ResourceContainer/ResourceContainer.css
+++ b/src/components/containers/ResourceContainer/ResourceContainer.css
@@ -52,9 +52,3 @@
   background-color: #6c757d;
   border-color: #6c757d;
 }
-
-.fhir-container__ResourceContainer__json-button-fhir-version {
-  font-size: 0.7rem;
-  color: red;
-  text-transform: uppercase;
-}

--- a/src/components/containers/ResourceContainer/ResourceContainer.js
+++ b/src/components/containers/ResourceContainer/ResourceContainer.js
@@ -17,7 +17,6 @@ class ResourceContainer extends React.Component {
     return (
       <div className="fhir-container__ResourceContainer__card">
         <div className="fhir-container__ResourceContainer__card-body">
-          {this.props.children}
           <div className="fhir-container__ResourceContainer__json-button-wrapper">
             <button
               type="button"
@@ -26,8 +25,14 @@ class ResourceContainer extends React.Component {
               data-target={`${this.props.fhirResource.resourceType}/${this.props.fhirResource.id}`}
             >
               JSON
+              {this.props.fhirVersion && (
+                <span className="fhir-container__ResourceContainer__json-button-fhir-version">
+                  &nbsp;{this.props.fhirVersion}
+                </span>
+              )}
             </button>
           </div>
+          {this.props.children}
           <div
             className={
               this.state.jsonOpen

--- a/src/components/containers/ResourceContainer/ResourceContainer.js
+++ b/src/components/containers/ResourceContainer/ResourceContainer.js
@@ -25,11 +25,6 @@ class ResourceContainer extends React.Component {
               data-target={`${this.props.fhirResource.resourceType}/${this.props.fhirResource.id}`}
             >
               JSON
-              {this.props.fhirVersion && (
-                <span className="fhir-container__ResourceContainer__json-button-fhir-version">
-                  &nbsp;{this.props.fhirVersion}
-                </span>
-              )}
             </button>
           </div>
           {this.props.children}

--- a/src/components/containers/ResourceContainer/ResourceContainer.stories.js
+++ b/src/components/containers/ResourceContainer/ResourceContainer.stories.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { object } from '@storybook/addon-knobs';
+
+import ResourceContainer from './ResourceContainer';
+import Encounter from '../../../components/resources/Encounter';
+
+import example1 from '../../../fixtures/dstu2/resources/encounter/example.json';
+import fhirVersions from '../../../components/resources/fhirResourceVersions';
+
+export default {
+  title: 'ResourceContainer',
+};
+
+export const DefaultVisualization = () => {
+  const fhirResource = object('Resource', example1);
+  const props = {
+    fhirVersion: fhirVersions.DSTU2,
+    fhirResource: fhirResource,
+  };
+  return (
+    <ResourceContainer {...props}>
+      <Encounter {...props} />
+    </ResourceContainer>
+  );
+};
+
+export const VisualizationWithoutFhirVersion = () => {
+  const fhirResource = object('Resource', example1);
+  const props = {
+    fhirResource: fhirResource,
+  };
+  return (
+    <ResourceContainer {...props}>
+      <Encounter {...props} />
+    </ResourceContainer>
+  );
+};

--- a/src/components/resources/UnhandledResourceDataStructure/UnhandledResourceDataStructure.js
+++ b/src/components/resources/UnhandledResourceDataStructure/UnhandledResourceDataStructure.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const UnhandledResourceDataStructure = ({ resourceName = '' }) => (
-  <div>
+  <div className="fhir-resource">
     <h4>Unhandled data structure for {resourceName} resource component</h4>
     <small>
       Please check if component has proper <b>fhirVersion</b> property.

--- a/src/components/ui/bootstrap-reboot.min.css
+++ b/src/components/ui/bootstrap-reboot.min.css
@@ -6,13 +6,12 @@
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md)
  */
-*,
-::after,
-::before {
+.fhir-resource *,
+.fhir-resource::after,
+.fhir-resource::before {
   box-sizing: border-box;
 }
-body {
-  margin: 0;
+.fhir-resource {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
     'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
@@ -23,55 +22,56 @@ body {
   background-color: #fff;
   -webkit-text-size-adjust: 100%;
   -webkit-tap-highlight-color: transparent;
+  padding: 1rem;
 }
-[tabindex='-1']:focus:not(:focus-visible) {
+.fhir-resource [tabindex='-1']:focus:not(:focus-visible) {
   outline: 0 !important;
 }
-hr {
+.fhir-resource hr {
   margin: 1rem 0;
   color: inherit;
   background-color: currentColor;
   border: 0;
   opacity: 0.25;
 }
-hr:not([size]) {
+.fhir-resource hr:not([size]) {
   height: 1px;
 }
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+.fhir-resource h1,
+.fhir-resource h2,
+.fhir-resource h3,
+.fhir-resource h4,
+.fhir-resource h5,
+.fhir-resource h6 {
   margin-top: 0;
   margin-bottom: 0.5rem;
   font-weight: 500;
   line-height: 1.2;
 }
-h1 {
+.fhir-resource h1 {
   font-size: 2.5rem;
 }
-h2 {
+.fhir-resource h2 {
   font-size: 2rem;
 }
-h3 {
+.fhir-resource h3 {
   font-size: 1.75rem;
 }
-h4 {
+.fhir-resource h4 {
   font-size: 1.5rem;
 }
-h5 {
+.fhir-resource h5 {
   font-size: 1.25rem;
 }
-h6 {
+.fhir-resource h6 {
   font-size: 1rem;
 }
-p {
+.fhir-resource p {
   margin-top: 0;
   margin-bottom: 1rem;
 }
-abbr[data-original-title],
-abbr[title] {
+.fhir-resource abbr[data-original-title],
+.fhir-resource abbr[title] {
   text-decoration: underline;
   -webkit-text-decoration: underline dotted;
   text-decoration: underline dotted;
@@ -79,144 +79,144 @@ abbr[title] {
   -webkit-text-decoration-skip-ink: none;
   text-decoration-skip-ink: none;
 }
-address {
+.fhir-resource address {
   margin-bottom: 1rem;
   font-style: normal;
   line-height: inherit;
 }
-ol,
-ul {
+.fhir-resource ol,
+.fhir-resource ul {
   padding-left: 2rem;
 }
-dl,
-ol,
-ul {
+.fhir-resource dl,
+.fhir-resource ol,
+.fhir-resource ul {
   margin-top: 0;
   margin-bottom: 0;
 }
-ol ol,
-ol ul,
-ul ol,
-ul ul {
+.fhir-resource ol ol,
+.fhir-resource ol ul,
+.fhir-resource ul ol,
+.fhir-resource ul ul {
   margin-bottom: 0;
 }
-dt {
+.fhir-resource dt {
   font-weight: 700;
 }
-dd {
+.fhir-resource dd {
   margin-bottom: 0.5rem;
   margin-left: 0;
 }
-blockquote {
+.fhir-resource blockquote {
   margin: 0 0 1rem;
 }
-b,
+.fhir-resource b,
 strong {
   font-weight: bolder;
 }
-small {
+.fhir-resource small {
   font-size: 0.875em;
 }
-sub,
+.fhir-resource sub,
 sup {
   position: relative;
   font-size: 0.75em;
   line-height: 0;
   vertical-align: baseline;
 }
-sub {
+.fhir-resource sub {
   bottom: -0.25em;
 }
-sup {
+.fhir-resource sup {
   top: -0.5em;
 }
-a {
+.fhir-resource a {
   color: #0d6efd;
   text-decoration: none;
 }
-a:hover {
+.fhir-resource a:hover {
   color: #024dbc;
   text-decoration: underline;
 }
-a:not([href]),
-a:not([href]):hover {
+.fhir-resource a:not([href]),
+.fhir-resource a:not([href]):hover {
   color: inherit;
   text-decoration: none;
 }
-code,
-kbd,
-pre,
-samp {
+.fhir-resource code,
+.fhir-resource kbd,
+.fhir-resource pre,
+.fhir-resource samp {
   font-family: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
     'Courier New', monospace;
   font-size: 1em;
 }
-pre {
+.fhir-resource pre {
   display: block;
   margin-top: 0;
   margin-bottom: 1rem;
   overflow: auto;
   font-size: 0.875em;
 }
-pre code {
+.fhir-resource pre code {
   font-size: inherit;
   color: inherit;
   word-break: normal;
 }
-code {
+.fhir-resource code {
   font-size: 0.875em;
   color: #d63384;
   word-wrap: break-word;
 }
-a > code {
+.fhir-resource a > code {
   color: inherit;
 }
-kbd {
+.fhir-resource kbd {
   padding: 0.2rem 0.4rem;
   font-size: 0.875em;
   color: #fff;
   background-color: #212529;
   border-radius: 0.2rem;
 }
-kbd kbd {
+.fhir-resource kbd kbd {
   padding: 0;
   font-size: 1em;
   font-weight: 700;
 }
-figure {
+.fhir-resource figure {
   margin: 0 0 1rem;
 }
-img {
+.fhir-resource img {
   vertical-align: middle;
 }
-svg {
+.fhir-resource svg {
   overflow: hidden;
   vertical-align: middle;
 }
-table {
+.fhir-resource table {
   border-collapse: collapse;
 }
-caption {
+.fhir-resource caption {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
   color: #6c757d;
   text-align: left;
   caption-side: bottom;
 }
-th {
+.fhir-resource th {
   text-align: inherit;
 }
-label {
+.fhir-resource label {
   display: inline-block;
 }
-button {
+.fhir-resource button {
   border-radius: 0;
 }
-button:focus {
+.fhir-resource button:focus {
   outline: 1px dotted;
   outline: 5px auto -webkit-focus-ring-color;
 }
-button,
+.fhir-resource button,
 input,
 optgroup,
 select,
@@ -226,53 +226,53 @@ textarea {
   font-size: inherit;
   line-height: inherit;
 }
-button,
+.fhir-resource button,
 input {
   overflow: visible;
 }
-button,
+.fhir-resource button,
 select {
   text-transform: none;
 }
-select {
+.fhir-resource select {
   word-wrap: normal;
 }
-[list]::-webkit-calendar-picker-indicator {
+.fhir-resource [list]::-webkit-calendar-picker-indicator {
   display: none;
 }
-[type='button'],
+.fhir-resource [type='button'],
 [type='reset'],
 [type='submit'],
 button {
   -webkit-appearance: button;
 }
-[type='button']:not(:disabled),
+.fhir-resource [type='button']:not(:disabled),
 [type='reset']:not(:disabled),
 [type='submit']:not(:disabled),
 button:not(:disabled) {
   cursor: pointer;
 }
-::-moz-focus-inner {
+.fhir-resource ::-moz-focus-inner {
   padding: 0;
   border-style: none;
 }
-input[type='date'],
+.fhir-resource input[type='date'],
 input[type='datetime-local'],
 input[type='month'],
 input[type='time'] {
   -webkit-appearance: textfield;
 }
-textarea {
+.fhir-resource textarea {
   overflow: auto;
   resize: vertical;
 }
-fieldset {
+.fhir-resource fieldset {
   min-width: 0;
   padding: 0;
   margin: 0;
   border: 0;
 }
-legend {
+.fhir-resource legend {
   float: left;
   width: 100%;
   padding: 0;
@@ -282,45 +282,45 @@ legend {
   color: inherit;
   white-space: normal;
 }
-mark {
+.fhir-resource mark {
   padding: 0.2em;
   background-color: #fcf8e3;
 }
-progress {
+.fhir-resource progress {
   vertical-align: baseline;
 }
-::-webkit-datetime-edit {
+.fhir-resource ::-webkit-datetime-edit {
   overflow: visible;
   line-height: 0;
 }
-[type='search'] {
+.fhir-resource [type='search'] {
   outline-offset: -2px;
   -webkit-appearance: textfield;
 }
-::-webkit-search-decoration {
+.fhir-resource ::-webkit-search-decoration {
   -webkit-appearance: none;
 }
-::-webkit-color-swatch-wrapper {
+.fhir-resource ::-webkit-color-swatch-wrapper {
   padding: 0;
 }
-::-webkit-file-upload-button {
+.fhir-resource ::-webkit-file-upload-button {
   font: inherit;
   -webkit-appearance: button;
 }
-output {
+.fhir-resource output {
   display: inline-block;
 }
-summary {
+.fhir-resource summary {
   display: list-item;
   cursor: pointer;
 }
-template {
+.fhir-resource template {
   display: none;
 }
-main {
+.fhir-resource main {
   display: block;
 }
-[hidden] {
+.fhir-resource [hidden] {
   display: none !important;
 }
 /*# sourceMappingURL=bootstrap-reboot.min.css.map */

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import './bootstrap-reboot.min.css';
 import './index.css';
 
 export const Header = props => (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   mode: process.env.NODE_ENV,
@@ -25,6 +26,10 @@ module.exports = {
       },
       {
         test: /\.css$/,
+        exclude: path.resolve(
+          __dirname,
+          'src/components/ui/bootstrap-reboot.min.css',
+        ),
         use: [
           {
             loader: MiniCssExtractPlugin.loader,
@@ -41,5 +46,11 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: 'style.css',
     }),
+    new CopyWebpackPlugin([
+      {
+        from: 'src/components/ui/bootstrap-reboot.min.css',
+        to: '',
+      },
+    ]),
   ],
 };


### PR DESCRIPTION
DONE:
 - refactor the way of injection the `bootstrap-reboot` CSS file
 - refactor CSS styles, so that do not effects a base html elements (CSS styles effects only elements that has `fhir-resource` class name)
 - refactor the "JSON" button element; now presents information what is the resource version


<img width="1138" alt="Screenshot 2020-02-24 at 16 03 23" src="https://user-images.githubusercontent.com/6116778/75163323-4e734000-571f-11ea-8597-a566b736826e.png">
<img width="1140" alt="Screenshot 2020-02-24 at 16 03 31" src="https://user-images.githubusercontent.com/6116778/75163333-5206c700-571f-11ea-9cee-cf361c46d9f6.png">
