### PR TITLE
add R4 support to MedicationStatement component

### DIFF
--- a/src/components/resources/MedicationStatement/MedicationStatement.js
+++ b/src/components/resources/MedicationStatement/MedicationStatement.js
@@ -39,6 +39,8 @@ const MedicationDetails = props => {
   );
 };
 
+const DEFAULT_TITLE = 'Medication Statement';
+
 const commonDTO = fhirResource => {
   const status = _get(fhirResource, 'status', '');
   const hasEffectivePeriod = _has(fhirResource, 'effectivePeriod');
@@ -71,7 +73,11 @@ const dstu2DTO = fhirResource => {
   const title = _get(
     fhirResource,
     'medicationCodeableConcept.text',
-    _get(fhirResource, 'medicationCodeableConcept.coding[0].display'),
+    _get(
+      fhirResource,
+      'medicationCodeableConcept.coding[0].display',
+      DEFAULT_TITLE,
+    ),
   );
   return {
     title,
@@ -81,7 +87,11 @@ const stu3DTO = fhirResource => {
   const title = _get(
     fhirResource,
     'medicationCodeableConcept.text',
-    _get(fhirResource, 'medicationCodeableConcept.coding[0].display'),
+    _get(
+      fhirResource,
+      'medicationCodeableConcept.coding[0].display',
+      DEFAULT_TITLE,
+    ),
   );
   const reasonCode = _get(fhirResource, 'reasonCode');
   const hasReasonCode = Array.isArray(reasonCode);
@@ -142,7 +152,7 @@ const MedicationStatement = props => {
     hasMedications,
     hasDosage,
     hasReasonCode,
-    title = 'Medication Statement',
+    title,
     contained,
     reasonCode,
     hasNote,

--- a/src/components/resources/MedicationStatement/MedicationStatement.js
+++ b/src/components/resources/MedicationStatement/MedicationStatement.js
@@ -110,6 +110,13 @@ const resourceDTO = (fhirVersion, fhirResource) => {
         ...stu3DTO(fhirResource),
       };
     }
+    case fhirVersions.R4: {
+      // there are not any breaking changes between STU3 and R4 version
+      return {
+        ...commonDTO(fhirResource),
+        ...stu3DTO(fhirResource),
+      };
+    }
 
     default:
       throw Error('Unrecognized the fhir version property type.');
@@ -135,7 +142,7 @@ const MedicationStatement = props => {
     hasMedications,
     hasDosage,
     hasReasonCode,
-    title,
+    title = 'Medication Statement',
     contained,
     reasonCode,
     hasNote,

--- a/src/components/resources/MedicationStatement/MedicationStatement.stories.js
+++ b/src/components/resources/MedicationStatement/MedicationStatement.stories.js
@@ -2,11 +2,13 @@ import React from 'react';
 import { object } from '@storybook/addon-knobs';
 
 import MedicationStatement from './MedicationStatement';
+import fhirVersions from '../fhirResourceVersions';
 
 import dstu2Example1 from '../../../fixtures/dstu2/resources/medicationStatement/example1.json';
 import stu3Example1 from '../../../fixtures/stu3/resources/medicationStatement/example1.json';
 import stu3Example2 from '../../../fixtures/stu3/resources/medicationStatement/example2.json';
-import fhirVersions from '../fhirResourceVersions';
+import r4Example1 from '../../../fixtures/r4/resources/medicationStatement/example1.json';
+import r4Example2 from '../../../fixtures/r4/resources/medicationStatement/example2.json';
 
 export default {
   title: 'MedicationStatement',
@@ -37,6 +39,26 @@ export const Example2OfSTU3 = () => {
   return (
     <MedicationStatement
       fhirVersion={fhirVersions.STU3}
+      fhirResource={fhirResource}
+    />
+  );
+};
+
+export const Example1OfR4 = () => {
+  const fhirResource = object('Resource', r4Example1);
+  return (
+    <MedicationStatement
+      fhirVersion={fhirVersions.R4}
+      fhirResource={fhirResource}
+    />
+  );
+};
+
+export const Example2OfR4 = () => {
+  const fhirResource = object('Resource', r4Example2);
+  return (
+    <MedicationStatement
+      fhirVersion={fhirVersions.R4}
       fhirResource={fhirResource}
     />
   );

--- a/src/components/resources/MedicationStatement/MedicationStatement.test.js
+++ b/src/components/resources/MedicationStatement/MedicationStatement.test.js
@@ -4,6 +4,7 @@ import MedicationStatement from './MedicationStatement';
 import fhirVersions from '../fhirResourceVersions';
 import example1MedicationStatement from '../../../fixtures/dstu2/resources/medicationStatement/example1.json';
 import stu3Example from '../../../fixtures/stu3/resources/medicationStatement/example1.json';
+import r4Example1 from '../../../fixtures/r4/resources/medicationStatement/example1.json';
 
 describe('should render MedicationStatement component correctly', () => {
   it('with DSTU2 source data', () => {
@@ -32,7 +33,28 @@ describe('should render MedicationStatement component correctly', () => {
       <MedicationStatement {...defaultProps} />,
     );
 
-    expect(getByTestId('title').textContent).toEqual('');
+    expect(getByTestId('title').textContent).toEqual('Medication Statement');
+    expect(queryAllByTestId('hasEffectivePeriod')).toHaveLength(0);
+
+    expect(getByTestId('dosageInstruction').textContent).toContain(
+      '1-2 tablets once daily',
+    );
+
+    expect(getByTestId('hasNote').textContent).toContain('occasional');
+
+    expect(getByTestId('hasReasonCode').textContent).toContain('Legs');
+  });
+
+  it('with R4 source data', () => {
+    const defaultProps = {
+      fhirResource: r4Example1,
+      fhirVersion: fhirVersions.R4,
+    };
+    const { getByTestId, queryAllByTestId } = render(
+      <MedicationStatement {...defaultProps} />,
+    );
+
+    expect(getByTestId('title').textContent).toEqual('Medication Statement');
     expect(queryAllByTestId('hasEffectivePeriod')).toHaveLength(0);
 
     expect(getByTestId('dosageInstruction').textContent).toContain(

--- a/src/fixtures/r4/resources/medicationStatement/example1.json
+++ b/src/fixtures/r4/resources/medicationStatement/example1.json
@@ -1,0 +1,198 @@
+{
+  "resourceType": "MedicationStatement",
+  "id": "example001",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example001</p><p><b>contained</b>: </p><p><b>identifier</b>: 12345689 (OFFICIAL)</p><p><b>status</b>: active</p><p><b>category</b>: Inpatient <span>(Details : {http://terminology.hl7.org/CodeSystem/medication-statement-category code 'inpatient' = 'Inpatient', given as 'Inpatient'})</span></p><p><b>medication</b>: id: med0309; Tylenol PM <span>(Details : {http://hl7.org/fhir/sid/ndc code '50580-506-02' = 'n/a', given as 'Tylenol PM'})</span>; Film-coated tablet (qualifier value) <span>(Details : {SNOMED CT code '385057009' = 'Film-coated tablet', given as 'Film-coated tablet (qualifier value)'})</span></p><p><b>subject</b>: <a>Donald Duck</a></p><p><b>effective</b>: 23/01/2015</p><p><b>dateAsserted</b>: 22/02/2015</p><p><b>informationSource</b>: <a>Donald Duck</a></p><p><b>derivedFrom</b>: <a>MedicationRequest/medrx002</a></p><p><b>reasonCode</b>: Restless Legs <span>(Details : {SNOMED CT code '32914008' = 'Restless legs', given as 'Restless Legs'})</span></p><p><b>note</b>: Patient indicates they miss the occasional dose</p><p><b>dosage</b>: </p></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "med0309",
+      "code": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/sid/ndc",
+            "code": "50580-506-02",
+            "display": "Tylenol PM"
+          }
+        ]
+      },
+      "form": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "385057009",
+            "display": "Film-coated tablet (qualifier value)"
+          }
+        ]
+      },
+      "ingredient": [
+        {
+          "itemCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                "code": "315266",
+                "display": "Acetaminophen 500 MG"
+              }
+            ]
+          },
+          "strength": {
+            "numerator": {
+              "value": 500,
+              "system": "http://unitsofmeasure.org",
+              "code": "mg"
+            },
+            "denominator": {
+              "value": 1,
+              "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+              "code": "Tab"
+            }
+          }
+        },
+        {
+          "itemCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                "code": "901813",
+                "display": "Diphenhydramine Hydrochloride 25 mg"
+              }
+            ]
+          },
+          "strength": {
+            "numerator": {
+              "value": 25,
+              "system": "http://unitsofmeasure.org",
+              "code": "mg"
+            },
+            "denominator": {
+              "value": 1,
+              "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+              "code": "Tab"
+            }
+          }
+        }
+      ],
+      "batch": {
+        "lotNumber": "9494788",
+        "expirationDate": "2017-05-22"
+      }
+    }
+  ],
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://www.bmc.nl/portal/medstatements",
+      "value": "12345689"
+    }
+  ],
+  "status": "active",
+  "category": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/medication-statement-category",
+        "code": "inpatient",
+        "display": "Inpatient"
+      }
+    ]
+  },
+  "medicationReference": {
+    "reference": "#med0309"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "effectiveDateTime": "2015-01-23",
+  "dateAsserted": "2015-02-22",
+  "informationSource": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "derivedFrom": [
+    {
+      "reference": "MedicationRequest/medrx002"
+    }
+  ],
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "32914008",
+          "display": "Restless Legs"
+        }
+      ]
+    }
+  ],
+  "note": [
+    {
+      "text": "Patient indicates they miss the occasional dose"
+    }
+  ],
+  "dosage": [
+    {
+      "sequence": 1,
+      "text": "1-2 tablets once daily at bedtime as needed for restless legs",
+      "additionalInstruction": [
+        {
+          "text": "Taking at bedtime"
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "asNeededCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "32914008",
+            "display": "Restless Legs"
+          }
+        ]
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "ordered",
+                "display": "Ordered"
+              }
+            ]
+          },
+          "doseRange": {
+            "low": {
+              "value": 1,
+              "unit": "TAB",
+              "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+              "code": "TAB"
+            },
+            "high": {
+              "value": 2,
+              "unit": "TAB",
+              "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+              "code": "TAB"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/fixtures/r4/resources/medicationStatement/example2.json
+++ b/src/fixtures/r4/resources/medicationStatement/example2.json
@@ -1,0 +1,77 @@
+{
+  "resourceType": "MedicationStatement",
+  "id": "example003",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example003</p><p><b>status</b>: active</p><p><b>medication</b>: Little Pink Pill for water retention <span>(Details )</span></p><p><b>subject</b>: <a>Donald Duck</a></p><p><b>effective</b>: 01/02/2014</p><p><b>dateAsserted</b>: 22/02/2014</p><p><b>informationSource</b>: <a>Donald Duck</a></p><p><b>reasonReference</b>: <a>Observation/blood-pressure</a></p><p><b>note</b>: Patient cannot remember the name of the tablet, but takes it every day in the morning for water retention</p><p><b>dosage</b>: </p></div>"
+  },
+  "status": "active",
+  "medicationCodeableConcept": {
+    "text": "Little Pink Pill for water retention"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "effectiveDateTime": "2014-02-01",
+  "dateAsserted": "2014-02-22",
+  "informationSource": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "reasonReference": [
+    {
+      "reference": "Observation/blood-pressure"
+    }
+  ],
+  "note": [
+    {
+      "text": "Patient cannot remember the name of the tablet, but takes it every day in the morning for water retention"
+    }
+  ],
+  "dosage": [
+    {
+      "sequence": 1,
+      "text": "1 tablet per day",
+      "asNeededBoolean": false,
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "260548002",
+            "display": "Oral"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "ordered",
+                "display": "Ordered"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 1,
+            "unit": "tab",
+            "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+            "code": "tab"
+          }
+        }
+      ],
+      "maxDosePerPeriod": {
+        "numerator": {
+          "value": 1
+        },
+        "denominator": {
+          "value": 1,
+          "system": "http://unitsofmeasure.org",
+          "code": "d"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
issue: https://github.com/1uphealth/fhir-react/issues/138

DONE: 
 - added R4 support to MedicationStatement component
 - add stories for Storybook, examples of resource data
 - add tests

<img width="1092" alt="Screenshot 2020-02-26 at 13 33 05" src="https://user-images.githubusercontent.com/6116778/75346150-61f8e500-589e-11ea-92e9-9d9b7bdd64af.png">
