### PR TITLE
Add ability render custom PDF components using Binary resource

### DIFF
--- a/src/components/resources/Binary/Binary.js
+++ b/src/components/resources/Binary/Binary.js
@@ -11,6 +11,12 @@ const Binary = props => {
       {(() => {
         switch (fhirResource.contentType) {
           case 'application/pdf':
+            if (props.children && typeof props.children === 'function') {
+              return props.children(
+                fhirResource.content,
+                fhirResource.contentType,
+              );
+            }
             return <Pdf fhirResource={fhirResource} />;
           case 'image/jpeg':
             return <Img fhirResource={fhirResource} />;


### PR DESCRIPTION
I've used render props to give the ability to render a PDF component in a different way than the default one.
It exposes data type as well as base64 content of the PDF to use in a custom component if needed. 

Example CodeSandbox:
https://codesandbox.io/s/binaryresourcepdf-fhrf9?file=/src/App.js