### PR TITLE
Change 'date' source of 'Issued On' field for Observation resource

### DIFF
--- a/src/components/resources/Observation/Observation.js
+++ b/src/components/resources/Observation/Observation.js
@@ -18,7 +18,7 @@ import Reference from '../../datatypes/Reference';
 
 const Observation = props => {
   const { fhirResource } = props;
-  const { issued } = fhirResource;
+  const effectiveDate = _get(fhirResource, 'effectiveDateTime');
   const codeCodingDisplay = _get(fhirResource, 'code.coding.0.display');
   const codeText = _get(fhirResource, 'code.text', '');
   const valueQuantityValue = _get(fhirResource, 'valueQuantity.value', '');
@@ -65,9 +65,9 @@ const Observation = props => {
           valueQuantity={fhirResource.valueQuantity}
           referenceRange={fhirResource.referenceRange}
         />
-        {issued && (
+        {effectiveDate && (
           <Value label="Issued on" data-testid="issuedOn">
-            <Date fhirData={issued} />
+            <Date fhirData={effectiveDate} />
           </Value>
         )}
         {subject && (

--- a/src/components/resources/Observation/Observation.test.js
+++ b/src/components/resources/Observation/Observation.test.js
@@ -5,26 +5,15 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import Observation from './Observation';
 
-import exampleObservation from '../../../fixtures/dstu2/resources/observation/example.json';
 import exampleObservationIssued from '../../../fixtures/dstu2/resources/observation/example-issued.json';
 
-import exampleObservationSTU3 from '../../../fixtures/stu3/resources/observation/example-weight.json';
 import exampleObservationExcessSTU3 from '../../../fixtures/stu3/resources/observation/example-f002-excess.json';
 
 import example1ObservationExcessR4 from '../../../fixtures/r4/resources/observation/example2.json';
 import example2ObservationExcessR4 from '../../../fixtures/r4/resources/observation/example3.json';
 
 describe('should render component correctly', () => {
-  it('DSTU2 - without issued field', () => {
-    const defaultProps = {
-      fhirResource: exampleObservation,
-    };
-    const { container } = render(<Observation {...defaultProps} />);
-
-    expect(container).not.toBeNull();
-  });
-
-  test('DSTU2 - with issued field', () => {
+  test('DSTU2 renders properly', () => {
     const defaultProps = {
       fhirResource: exampleObservationIssued,
     };
@@ -33,16 +22,7 @@ describe('should render component correctly', () => {
     expect(container).not.toBeNull();
   });
 
-  test('DSTU3 - without issued field', () => {
-    const defaultProps = {
-      fhirResource: exampleObservationSTU3,
-    };
-    const { container } = render(<Observation {...defaultProps} />);
-
-    expect(container).not.toBeNull();
-  });
-
-  test('DSTU3 - with issued field', () => {
+  test('DSTU3 renders properly', () => {
     const defaultProps = {
       fhirResource: exampleObservationExcessSTU3,
     };
@@ -51,11 +31,11 @@ describe('should render component correctly', () => {
     expect(container).not.toBeNull();
   });
 
-  test('R4 - with issued field', () => {
+  test('R4 renders properly, example 1', () => {
     const defaultProps = {
       fhirResource: example1ObservationExcessR4,
     };
-    const { container, getByTestId } = render(
+    const { container, getByTestId, queryByTestId } = render(
       <Observation {...defaultProps} />,
     );
 
@@ -64,15 +44,15 @@ describe('should render component correctly', () => {
       'Glucose [Moles/volume] in Blood',
     );
     expect(getByTestId('status').textContent).toEqual('final');
-    expect(getByTestId('issuedOn').textContent).toEqual('2013-04-03');
+    expect(queryByTestId('issuedOn')).toBeNull();
     expect(getByTestId('subject').textContent).toContain('P. van de Heuvel');
   });
 
-  test('R4 - with issued field - example 2', () => {
+  test('R4 renders properly, example 2', () => {
     const defaultProps = {
       fhirResource: example2ObservationExcessR4,
     };
-    const { container, getByTestId, queryByTestId, queryByText } = render(
+    const { container, getByTestId, queryByText } = render(
       <Observation {...defaultProps} />,
     );
 
@@ -82,7 +62,7 @@ describe('should render component correctly', () => {
     );
     expect(getByTestId('status').textContent).toEqual('final');
     expect(getByTestId('secondaryStatus').textContent).toEqual('YES');
-    expect(queryByTestId('issuedOn')).toBeNull();
+    expect(getByTestId('issuedOn').textContent).toEqual('2016-05-18');
     expect(getByTestId('subject').textContent).toContain('Patient/infant');
     expect(queryByText('373066001')).not.toBeNull();
   });


### PR DESCRIPTION
Changed the source of getting the information for `Issued On` field to `effectiveDateTime`, so date shows the time of the observation and not the time of observation being issued on.