### PR TITLE
add digitsToRoundForQuantity as optional props to the Observation component an…

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "useTabs": false,
   "semi": true,
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "arrowParens": "avoid"
 }

--- a/src/components/resources/Observation/Observation.js
+++ b/src/components/resources/Observation/Observation.js
@@ -43,7 +43,7 @@ const Observation = props => {
 
   if (
     _isFinite(Number(props.digitsToRoundForQuantity)) &&
-    valueQuantityValue != '' &&
+    valueQuantityValue !== '' &&
     _isFinite(Number(valueQuantityValue))
   ) {
     valueQuantityValueNumber = Number(valueQuantityValue).toFixed(

--- a/src/components/resources/Observation/Observation.js
+++ b/src/components/resources/Observation/Observation.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import _get from 'lodash/get';
+import _isFinite from 'lodash/isFinite';
 import Coding from '../../datatypes/Coding';
 import Date from '../../datatypes/Date';
 import ObservationGraph from './ObservationGraph';
@@ -38,7 +39,19 @@ const Observation = props => {
     [],
   );
 
-  const valueQuantityString = `${valueQuantityValue}${valueQuantityUnit}`.trim();
+  let valueQuantityValueNumber = valueQuantityValue;
+
+  if (
+    _isFinite(Number(props.digitsToRoundForQuantity)) &&
+    valueQuantityValue != '' &&
+    _isFinite(Number(valueQuantityValue))
+  ) {
+    valueQuantityValueNumber = Number(valueQuantityValue).toFixed(
+      props.digitsToRoundForQuantity,
+    );
+  }
+
+  const valueQuantityString = `${valueQuantityValueNumber}${valueQuantityUnit}`.trim();
   const subject = _get(fhirResource, 'subject');
 
   return (
@@ -49,7 +62,7 @@ const Observation = props => {
           {valueQuantityString && (
             <>
               &nbsp;
-              <code>{valueQuantityString}</code>
+              <code data-testid="valueQuantity">{valueQuantityString}</code>
             </>
           )}
         </Title>
@@ -85,6 +98,11 @@ const Observation = props => {
 
 Observation.propTypes = {
   fhirResource: PropTypes.shape({}).isRequired,
+  digitsToRoundForQuantity: PropTypes.number,
+};
+
+Observation.defaultProps = {
+  digitsToRoundForQuantity: 2,
 };
 
 export default Observation;

--- a/src/components/resources/Observation/Observation.test.js
+++ b/src/components/resources/Observation/Observation.test.js
@@ -66,4 +66,31 @@ describe('should render component correctly', () => {
     expect(getByTestId('subject').textContent).toContain('Patient/infant');
     expect(queryByText('373066001')).not.toBeNull();
   });
+
+  test('should round the quantity to default value of digitsToRoundForQuantity props ', () => {
+    const resource = example1ObservationExcessR4;
+    resource.valueQuantity.value = 6.43534535434;
+
+    const defaultProps = {
+      fhirResource: example1ObservationExcessR4,
+    };
+    const { getByTestId } = render(<Observation {...defaultProps} />);
+
+    expect(getByTestId('valueQuantity')).not.toBeNull();
+    expect(getByTestId('valueQuantity').textContent).toEqual('6.44mmol/l');
+  });
+
+  test('should round the quantity to specific value of digitsToRoundForQuantity props ', () => {
+    const resource = example1ObservationExcessR4;
+    resource.valueQuantity.value = 6.43534535434;
+
+    const defaultProps = {
+      fhirResource: example1ObservationExcessR4,
+      digitsToRoundForQuantity: 3,
+    };
+    const { getByTestId } = render(<Observation {...defaultProps} />);
+
+    expect(getByTestId('valueQuantity')).not.toBeNull();
+    expect(getByTestId('valueQuantity').textContent).toEqual('6.435mmol/l');
+  });
 });


### PR DESCRIPTION
DONE:
 - add `digitsToRoundForQuantity` as optional props to the Observation component and set default value to 2

<img width="1062" alt="Screenshot 2020-08-25 at 15 10 14" src="https://user-images.githubusercontent.com/6116778/91179518-e52cb380-e6e6-11ea-92ad-0e9e1704f9c6.png">

