### PR TITLE
Change links to the Binary FHIR resource in DocumentReference

### DIFF
--- a/src/components/resources/DocumentReference/DocumentReference.test.js
+++ b/src/components/resources/DocumentReference/DocumentReference.test.js
@@ -56,7 +56,7 @@ describe('should render the DocumentReference component properly', () => {
     const sizes = getAllByTestId('content.size').map(node => node.textContent);
     expect(sizes).toEqual(['3.65 kB']);
     const urls = getAllByTestId('content.url').map(node => node.textContent);
-    expect(urls).toEqual(['Link']);
+    expect(urls).toEqual(['Binary/07a6483f-732b-461e-86b6-edb665c45510']);
   });
 
   it('should render with STU3 source data', () => {
@@ -105,7 +105,7 @@ describe('should render the DocumentReference component properly', () => {
     const sizes = getAllByTestId('content.size').map(node => node.textContent);
     expect(sizes).toEqual(['3.65 kB']);
     const urls = getAllByTestId('content.url').map(node => node.textContent);
-    expect(urls).toEqual(['Link']);
+    expect(urls).toEqual(['Binary/07a6483f-732b-461e-86b6-edb665c45510']);
   });
 
   it('should render with R4 source data', () => {
@@ -151,6 +151,50 @@ describe('should render the DocumentReference component properly', () => {
     const sizes = getAllByTestId('content.size').map(node => node.textContent);
     expect(sizes).toEqual(['3.65 kB']);
     const urls = getAllByTestId('content.url').map(node => node.textContent);
+    expect(urls).toEqual(['Binary/07a6483f-732b-461e-86b6-edb665c45510']);
+  });
+
+  it("should render link if it doesn't point to the Binary resource", () => {
+    const resource = JSON.parse(JSON.stringify(r4Example1));
+    resource.content[0].attachment.url = 'http://example.org/resource.pdf';
+    const { getAllByTestId } = render(
+      <DocumentReference
+        fhirResource={resource}
+        fhirVersion={fhirVersions.R4}
+      />,
+    );
+
+    const urls = getAllByTestId('content.url').map(node => node.textContent);
     expect(urls).toEqual(['Link']);
+  });
+
+  it('should render resource type and id if the URL points to the Binary resource in the 1up API', () => {
+    const resource = JSON.parse(JSON.stringify(r4Example1));
+    resource.content[0].attachment.url =
+      'https://api.1up.health/fhir/dstu2/Binary/123fds3fds45GDF4';
+    const { getAllByTestId } = render(
+      <DocumentReference
+        fhirResource={resource}
+        fhirVersion={fhirVersions.R4}
+      />,
+    );
+
+    const urls = getAllByTestId('content.url').map(node => node.textContent);
+    expect(urls).toEqual(['Binary/123fds3fds45GDF4']);
+  });
+
+  it('should render resource type and id if the URL points to the Binary resource on some domain', () => {
+    const resource = JSON.parse(JSON.stringify(r4Example1));
+    resource.content[0].attachment.url =
+      'http://example.org/xds/mhd/Binary/07a6483f-732b-461e-86b6-edb665c45510';
+    const { getAllByTestId } = render(
+      <DocumentReference
+        fhirResource={resource}
+        fhirVersion={fhirVersions.R4}
+      />,
+    );
+
+    const urls = getAllByTestId('content.url').map(node => node.textContent);
+    expect(urls).toEqual(['Binary/07a6483f-732b-461e-86b6-edb665c45510']);
   });
 });


### PR DESCRIPTION
closes #231 

## The problem
The DocumentReference component rendered attachment links that usually are Binary resources, as a link that points to the 1up API. When users try to open the link, they go to `https://api.1up.health/fhir/{fhirVersion}/Binary/{ID}, which results with the error page with 401 status code. Right now there is no way of opening different resources from the fhir-react.

## Solution
Instead of adding a link to resource like that, we are now generating the text in Reference format: `ResourceType/ResourceID`, which is more valuable for the user than not working link.

So if there is an URL ending with e.g. `Binary/21fds-342rd-2rd` it will be rendered as a text. If not, it will still be an external link.

### Done
- Add implementation of URL filtering
- Add tests for the link/resource names cases
- Deployed changes on the [Storybook](http://storybook-fhir-react-lib.s3-website-us-east-1.amazonaws.com/?path=/story/document-reference--default-visualization-dstu-2) 

## Examples
 "url": "https://api.1up.health/fhir/dstu2/Binary/123fds3fds45GDF4",
![image](https://user-images.githubusercontent.com/60238331/121682035-d8cde780-cabb-11eb-8c4d-d1eee8375825.png)

"url": "http://example.org/xds/mhd/Binary/07a6483f-732b-461e-86b6-edb665c45510",
![image](https://user-images.githubusercontent.com/60238331/121682086-eedba800-cabb-11eb-9364-0bc925adba7b.png)

"url": "http://example.org/path/someFile.pdf",
![image](https://user-images.githubusercontent.com/60238331/121682189-0d41a380-cabc-11eb-9803-c2aaf5b0782e.png)
