### PR TITLE
Patient names are displayed incorrectly if there are a lot of them

### DIFF
--- a/src/components/resources/Patient/Patient.js
+++ b/src/components/resources/Patient/Patient.js
@@ -30,7 +30,7 @@ export function getId(fhirResource) {
   return _get(fhirResource, 'id');
 }
 export function getNames(fhirResource) {
-  return _get(fhirResource, 'name', []);
+  return _get(fhirResource, 'name.0', null);
 }
 export function getBirthDate(fhirResource) {
   return _get(fhirResource, 'birthDate');
@@ -45,7 +45,7 @@ function Patient(props) {
   const id = getId(fhirResource);
   const idHash = md5(id || '');
   const avatarSrc = `http://www.gravatar.com/avatar/${idHash}?s=50&r=any&default=identicon&forcedefault=1`;
-  const patientNames = getNames(fhirResource);
+  const patientName = getNames(fhirResource);
   const patientBirthDate = getBirthDate(fhirResource);
   const patientGender = getGender(fhirResource);
   const patientContact = _get(fhirResource, 'contact[0]');
@@ -81,27 +81,19 @@ function Patient(props) {
           </div>
           <div>
             <div className="fhir-resource__Patient__patient-block">
-              {patientNames.map((patientName, index) => {
-                if (props.thorough === false && index !== 0) {
-                  return null;
-                } else {
-                  return (
-                    <React.Fragment key={index}>
-                      <span data-testid={`patientName-${index}`}>
-                        {renderName
-                          ? renderName({
-                              patientName,
-                              defaultName,
-                              fhirVersion,
-                              id,
-                            })
-                          : defaultName(patientName, index)}
-                      </span>
-                      &nbsp;&nbsp;
-                    </React.Fragment>
-                  );
-                }
-              })}
+              <React.Fragment>
+                <span data-testid={`patientName`}>
+                  {renderName
+                    ? renderName({
+                        patientName,
+                        defaultName,
+                        fhirVersion,
+                        id,
+                      })
+                    : defaultName(patientName, 0)}
+                </span>
+                &nbsp;&nbsp;
+              </React.Fragment>
             </div>
             <div>
               {active && (

--- a/src/components/resources/Patient/Patient.test.js
+++ b/src/components/resources/Patient/Patient.test.js
@@ -17,9 +17,9 @@ describe('should render component correctly', () => {
       <Patient {...defaultProps} />,
     );
 
-    expect(
-      getByTestId('patientName-0').textContent.replace(/\s+/g, ' '),
-    ).toEqual('Jason Argonaut (usual)');
+    expect(getByTestId('patientName').textContent.replace(/\s+/g, ' ')).toEqual(
+      'Jason Argonaut (usual)',
+    );
     expect(getByTestId('patientGender').textContent).toEqual('male');
     expect(getByTestId('patientBirthDate').textContent).toEqual('1985-08-01');
     expect(getByTestId('patientAddress').textContent).toEqual(
@@ -40,9 +40,9 @@ describe('should render component correctly', () => {
       <Patient {...defaultProps} />,
     );
 
-    expect(
-      getByTestId('patientName-0').textContent.replace(/\s+/g, ' '),
-    ).toEqual('John, X Doe (usual)');
+    expect(getByTestId('patientName').textContent.replace(/\s+/g, ' ')).toEqual(
+      'John, X Doe (usual)',
+    );
     expect(getByTestId('patientGender').textContent).toEqual('male');
     expect(getByTestId('patientBirthDate').textContent).toEqual('2014-06-01');
     expect(getByTestId('patientAddress').textContent).toEqual(' 05 99999 ');
@@ -67,9 +67,9 @@ describe('should render component correctly', () => {
       <Patient {...defaultProps} />,
     );
 
-    expect(
-      getByTestId('patientName-0').textContent.replace(/\s+/g, ' '),
-    ).toEqual('Peter, James Chalmers (official)');
+    expect(getByTestId('patientName').textContent.replace(/\s+/g, ' ')).toEqual(
+      'Peter, James Chalmers (official)',
+    );
     expect(getByTestId('patientGender').textContent).toEqual('male');
     expect(getByTestId('patientBirthDate').textContent).toEqual('1974-12-25');
     expect(getByTestId('patientAddress').textContent).toContain(


### PR DESCRIPTION
<!-- Add a link to the related issue here, e.g. #1234 -->
Issue:  #245 

---

<!-- Complete these steps to start getting this PR reviewed -->
##### PR Checklist
- [x] Give this PR a meaningful title
- [x] Add a link to the related issue at the top of this description (above)
- [x] Connect this PR with the related issue via ZenHub with the button below this text box (or at the bottom of the page after the PR is created)
- [x] Ensure your branch is up to date with the target branch and resolve any conflicts
- [x] Answer the below questions to describe your PR for reviewers
- [x] Request at least two reviewers using the "Reviewers" section on the right, usually including at least one reviewer from your team
- [x] Notify the requested reviewers in the #code-review Slack channel once the PR is ready for review

---

<!-- Answer these questions to describe the PR for reviewers -->

## Why are these changes needed?
<!-- Give context for reviewers who might not be familiar with the issue -->
If the Patient resource contains multiple names in the array, they are not displayed correctly.

## What changed?
<!-- Tell reviewers what to expect to see in your changeset, and include screenshots for any front-end/visual changes (do not upload PHI or secrets in screenshots) -->
Based on the Practitioner and other resources, only the first name is displayed (usually the 'official' one).  

**Note**: for the more advanced system of picking names to display - if needed -  we should create a separate ticket and it will require changes in multiple existing resources. 

![image](https://user-images.githubusercontent.com/60238331/128041552-c547dd89-35c8-4df8-be75-9d72bf696a77.png)

## How are these changes tested?
<!-- Explain how you verified these changes (unit/integration tests? manual verification?) and describe how the reviewers can verify the changes themselves (how to run the tests, what to look for in manual checks) - including regression of existing code (e.g. do all previously existing unit tests still pass?) -->
- All automatic tests are passing
- tested manually in the Storybook