### PR TITLE
Add a new container - Accordion

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "react": "^17.0.1"
   },
   "dependencies": {
+    "bootstrap": "^5.1.1",
     "dompurify": "^2.0.7",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",

--- a/src/assets/containers/Accordion/arrow.svg
+++ b/src/assets/containers/Accordion/arrow.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <g fill="#fff" stroke="#8f939a" stroke-width="1.2">
+    <path d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z" fill-rule="evenodd" fill="#8f939a"/>
+  </g>
+</svg>
+

--- a/src/components/containers/Accordion/Accordion.css
+++ b/src/components/containers/Accordion/Accordion.css
@@ -1,0 +1,8 @@
+.accordion-button::after {
+  background-image: url('../../../assets/containers/Accordion/arrow.svg');
+}
+
+.accordion-button:not(.collapsed)::after {
+  background-image: url('../../../assets/containers/Accordion/arrow.svg');
+  transform: rotate(-180deg);
+}

--- a/src/components/containers/Accordion/Accordion.js
+++ b/src/components/containers/Accordion/Accordion.js
@@ -1,0 +1,34 @@
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap/dist/js/bootstrap.min.js';
+import './Accordion.css';
+
+import React from 'react';
+
+const Accordion = props => {
+  const { headerData, bodyData } = props;
+  return (
+    <div className="accordion">
+      <div className="accordion-body">
+        <div className="accordion-item">
+          <div className="accordion-header" id="flush-headingOne">
+            <button
+              className="accordion-button collapsed text-dark bg-white shadow-none"
+              type="button"
+              data-bs-target="#collapseTarget"
+              data-bs-toggle="collapse"
+              aria-controls="collapseTarget"
+              aria-expanded="false"
+            >
+              <div className="d-flex justify-content-start">{headerData}</div>
+            </button>
+          </div>
+          <div className="accordion-collapse collapse " id="collapseTarget">
+            <div className="accordion-body">{bodyData}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Accordion;

--- a/src/components/containers/Accordion/Accordion.stories.js
+++ b/src/components/containers/Accordion/Accordion.stories.js
@@ -1,0 +1,74 @@
+import { BadgeSecondary, Body, MissingValue, Title, Value } from '../../ui';
+
+import Accordion from './Accordion';
+import Annotation from '../../datatypes/Annotation';
+import Date from '../../datatypes/Date';
+import Procedure from '../../resources/Procedure/Procedure';
+import React from 'react';
+import Reference from '../../datatypes/Reference';
+import _get from 'lodash/get';
+import example1 from '../../../fixtures/dstu2/resources/procedure/example1.json';
+import { object } from '@storybook/addon-knobs';
+import stu3Example1 from '../../../fixtures/stu3/resources/procedure/example1.json';
+
+export default {
+  title: 'Accordion',
+};
+
+export const DefaultVisualization = () => {
+  const fhirResource = object('Resource', stu3Example1);
+  console.log(fhirResource);
+  const title =
+    _get(fhirResource, 'code.coding[0].display') ||
+    _get(fhirResource, 'code.text');
+  const performedDateTime = _get(fhirResource, 'performedDateTime');
+  const performer = _get(fhirResource, 'performer', []);
+  const locationReference = _get(fhirResource, 'location[0]');
+  const reasonCode = _get(fhirResource, 'reasonCode', []);
+  const note = _get(fhirResource, 'note', []);
+
+  return (
+    <Accordion
+      headerData={
+        <div className="">
+          <Title>{title}</Title>
+          <div className="pb-3" />
+          <BadgeSecondary data-testid="performedDateTime">
+            <Date fhirData={performedDateTime} />
+          </BadgeSecondary>
+        </div>
+      }
+      bodyData={
+        <Body>
+          <Value label="Performed by">
+            {performer.map((item, i) => (
+              <div key={`item-${i}`}>
+                {_get(item, 'actor.display', <MissingValue />)}
+              </div>
+            ))}
+          </Value>
+          <Value label="Location" data-testid="location">
+            <Reference fhirData={locationReference} />
+          </Value>
+          <Value label="Reason" data-testid="hasReasonCode">
+            <Annotation fhirData={reasonCode} />
+          </Value>
+          <Value label="Notes" data-testid="hasNote">
+            <Annotation fhirData={note} />
+          </Value>
+        </Body>
+      }
+    />
+  );
+};
+
+export const ProcedureVisualization = () => {
+  const fhirResource = object('Resource', example1);
+
+  return (
+    <Accordion
+      headerData={<div className=""></div>}
+      bodyData={<Procedure fhirResource={fhirResource} />}
+    />
+  );
+};

--- a/src/components/containers/Accordion/index.js
+++ b/src/components/containers/Accordion/index.js
@@ -1,0 +1,3 @@
+import Accordion from './Accordion';
+
+export default Accordion;


### PR DESCRIPTION
<!-- Add a link to the related issue here, e.g. #1234 -->
Issue:  [#70](https://app.zenhub.com/workspaces/patient-app-6140de7e31081800158d8ecf/issues/1uphealth/patient/70)

---

<!-- Complete these steps to start getting this PR reviewed -->
##### PR Checklist
- [X] Give this PR a meaningful title
- [X] Add a link to the related issue at the top of this description (above)
- [ ] Connect this PR with the related issue via ZenHub with the button below this text box (or at the bottom of the page after the PR is created)
- [X] Ensure your branch is up to date with the target branch and resolve any conflicts
- [X] Answer the below questions to describe your PR for reviewers
- [ ] Request at least two reviewers using the "Reviewers" section on the right, usually including at least one reviewer from your team
- [ ] Notify the requested reviewers in the #code-review Slack channel once the PR is ready for review

---

## Why are these changes needed?
The new design assumes that FHIR-React components will be displayed as accordions. For this reason, I have added a new reusable component that will allow you to update older components that match your selected FHIR resource types more quickly.

## What changed?
New container was added, named Accordion. Also I have added the svg file from the design that is needed in Accordion container.

## How are these changes tested?
How the new container looks and behaves has been checked manually using the storybook