### PR TITLE
Date component displaying US date format

### DIFF
--- a/src/components/datatypes/Date/Date.js
+++ b/src/components/datatypes/Date/Date.js
@@ -1,11 +1,13 @@
 import React from 'react';
+import { formatDate } from '../../../utils/formatDate';
 
 const Date = props => {
   const { fhirData } = props;
   if (!fhirData) {
     return null;
   }
-  const dateValue = String(fhirData).slice(0, 10);
+  const locale = 'en-US';
+  const dateValue = formatDate(String(fhirData).slice(0, 10), locale);
   return <span className="fhir-datatype__Date">{dateValue}</span>;
 };
 

--- a/src/components/resources/AdverseEvent/AdverseEvent.test.js
+++ b/src/components/resources/AdverseEvent/AdverseEvent.test.js
@@ -16,7 +16,7 @@ describe('should render component correctly', () => {
 
     expect(getByTestId('title').textContent).toContain('Patient');
 
-    expect(getByTestId('date').textContent).toEqual('2017-01-29');
+    expect(getByTestId('date').textContent).toEqual('1/29/2017');
 
     expect(getByTestId('type').textContent).toContain('304386008');
 
@@ -36,7 +36,7 @@ describe('should render component correctly', () => {
 
     expect(getByTestId('title').textContent).toContain('Patient');
 
-    expect(getByTestId('date').textContent).toEqual('2017-01-29');
+    expect(getByTestId('date').textContent).toEqual('1/29/2017');
 
     expect(getByTestId('hasSeriousness').textContent).toContain('Non-serious');
 

--- a/src/components/resources/AllergyIntolerance/AllergyIntolerance.test.js
+++ b/src/components/resources/AllergyIntolerance/AllergyIntolerance.test.js
@@ -22,7 +22,7 @@ describe('should render component correctly', () => {
 
     expect(getByTestId('status').textContent).toContain('unconfirmed');
 
-    expect(getByTestId('recordedDate').textContent).toContain('2010-03-01');
+    expect(getByTestId('recordedDate').textContent).toContain('3/1/2010');
 
     expect(getByTestId('substance').textContent).toContain('PENICILLIN');
 
@@ -46,7 +46,7 @@ describe('should render component correctly', () => {
 
     expect(getByTestId('status').textContent).toContain('confirmed');
 
-    expect(getByTestId('recordedDate').textContent).toContain('2014-10-09');
+    expect(getByTestId('recordedDate').textContent).toContain('10/9/2014');
 
     expect(getByTestId('substance').textContent).toContain(
       'allergenic extract',
@@ -78,7 +78,7 @@ describe('should render component correctly', () => {
 
     expect(getByTestId('status').textContent).toContain('Confirmed');
 
-    expect(getByTestId('recordedDate').textContent).toContain('2014-10-09');
+    expect(getByTestId('recordedDate').textContent).toContain('10/9/2014');
 
     expect(getByTestId('substance').textContent).toContain(
       'allergenic extract',
@@ -114,7 +114,7 @@ describe('should render component correctly', () => {
 
     expect(getByTestId('status').textContent).toContain('Confirmed');
 
-    expect(getByTestId('recordedDate').textContent).toContain('2015-08-06');
+    expect(getByTestId('recordedDate').textContent).toContain('8/6/2015');
 
     expect(getByTestId('patient').textContent).toEqual('Patient/mom');
 

--- a/src/components/resources/Appointment/Appointment.test.js
+++ b/src/components/resources/Appointment/Appointment.test.js
@@ -24,7 +24,7 @@ describe('should render component correctly', () => {
       'Discussion on the results',
     );
     expect(getByTestId('status').textContent).toEqual('booked');
-    expect(getByTestId('startDate').textContent).toContain('2013-12-10');
+    expect(getByTestId('startDate').textContent).toContain('12/10/2013');
     expect(getByTestId('type').textContent).toContain('General Discussion');
     expect(getByTestId('participant').textContent).toContain(
       'Peter James Chalmers',
@@ -71,7 +71,7 @@ describe('should render component correctly', () => {
       'Discussion on the results',
     );
     expect(getByTestId('status').textContent).toEqual('booked');
-    expect(getByTestId('startDate').textContent).toContain('2013-12-10');
+    expect(getByTestId('startDate').textContent).toContain('12/10/2013');
 
     expect(getByTestId('participant').textContent).toContain(
       'Peter James Chalmers',
@@ -108,7 +108,7 @@ describe('should render component correctly', () => {
       'Discussion on the results',
     );
     expect(getByTestId('status').textContent).toEqual('booked');
-    expect(getByTestId('startDate').textContent).toContain('2013-12-10');
+    expect(getByTestId('startDate').textContent).toContain('12/10/2013');
 
     expect(getByTestId('participant').textContent).toContain(
       'Peter James Chalmers',

--- a/src/components/resources/CarePlan/CarePlan.test.js
+++ b/src/components/resources/CarePlan/CarePlan.test.js
@@ -42,7 +42,7 @@ describe('should render component correctly', () => {
     expect(getByTestId('subject').textContent).toContain('Peter James');
     expect(getByTestId('subject').textContent).toContain('Patient/example');
     expect(getByTestId('author').textContent).toContain('Dr Adam Careful');
-    expect(getByTestId('periodEnd').textContent).toEqual('2017-06-01');
+    expect(getByTestId('periodEnd').textContent).toEqual('6/1/2017');
     expect(getByTestId('basedOn').textContent).toEqual(
       'Management of Type 2 Diabetes',
     );
@@ -67,7 +67,7 @@ describe('should render component correctly', () => {
     expect(getByTestId('subject').textContent).toContain('Peter James');
     expect(getByTestId('subject').textContent).toContain('Patient/example');
     expect(getByTestId('author').textContent).toContain('Dr Adam Careful');
-    expect(getByTestId('periodEnd').textContent).toEqual('2017-06-01');
+    expect(getByTestId('periodEnd').textContent).toEqual('6/1/2017');
     expect(getByTestId('basedOn').textContent).toEqual(
       'Management of Type 2 Diabetes',
     );
@@ -89,7 +89,7 @@ describe('should render component correctly', () => {
     expect(getByTestId('goals').textContent).toEqual('#goal');
     expect(getByTestId('subject').textContent).toContain('Eve Everywoman');
     expect(getByTestId('subject').textContent).toContain('Patient/1');
-    expect(getByTestId('periodStart').textContent).toEqual('2013-01-01');
-    expect(getByTestId('periodEnd').textContent).toEqual('2013-10-01');
+    expect(getByTestId('periodStart').textContent).toEqual('1/1/2013');
+    expect(getByTestId('periodEnd').textContent).toEqual('10/1/2013');
   });
 });

--- a/src/components/resources/CareTeam/CareTeam.test.js
+++ b/src/components/resources/CareTeam/CareTeam.test.js
@@ -24,7 +24,7 @@ describe('should render the CareTeam component properly', () => {
     );
     expect(getByTestId('status').textContent).toEqual('active');
     expect(queryByTestId('periodStart')).toBeNull();
-    expect(getByTestId('periodEnd').textContent).toEqual('2013-01-01');
+    expect(getByTestId('periodEnd').textContent).toEqual('1/1/2013');
     expect(getByTestId('category').textContent.trim()).toEqual('(encounter)');
     expect(getByTestId('subject').textContent).toContain(
       'Peter James Chalmers',
@@ -53,7 +53,7 @@ describe('should render the CareTeam component properly', () => {
     const periodEnds = getAllByTestId('participant.periodEnd').map(
       n => n.textContent,
     );
-    expect(periodEnds).toEqual(['-', '2013-01-01']);
+    expect(periodEnds).toEqual(['-', '1/1/2013']);
   });
 
   it('should render participants with STU3 source data when structure source data of Participants Role is coding array', () => {
@@ -83,7 +83,7 @@ describe('should render the CareTeam component properly', () => {
     );
     expect(getByTestId('status').textContent).toEqual('active');
     expect(queryByTestId('periodStart')).toBeNull();
-    expect(getByTestId('periodEnd').textContent).toEqual('2013-01-01');
+    expect(getByTestId('periodEnd').textContent).toEqual('1/1/2013');
     expect(getByTestId('encounter').textContent).toEqual('Encounter/example');
     expect(getByTestId('category').textContent).toContain(
       'Encounter-focused care team',
@@ -115,6 +115,6 @@ describe('should render the CareTeam component properly', () => {
     const periodEnds = getAllByTestId('participant.periodEnd').map(
       n => n.textContent,
     );
-    expect(periodEnds).toEqual(['-', '2013-01-01']);
+    expect(periodEnds).toEqual(['-', '1/1/2013']);
   });
 });

--- a/src/components/resources/Claim/Claim.test.js
+++ b/src/components/resources/Claim/Claim.test.js
@@ -23,7 +23,7 @@ describe('should render the Claim component properly', () => {
     expect(getByTestId('title').textContent).toEqual('Claim #100150');
     expect(getByTestId('use').textContent).toEqual('complete');
     expect(getByTestId('type').textContent).toContain('oral');
-    expect(getByTestId('created').textContent).toEqual('2014-08-16');
+    expect(getByTestId('created').textContent).toEqual('8/16/2014');
     expect(getByTestId('priority').textContent).toContain('normal');
     expect(getByTestId('insurer').textContent).toEqual('Organization/2');
     expect(getByTestId('payee.type').textContent).toContain('provider');
@@ -45,7 +45,7 @@ describe('should render the Claim component properly', () => {
     expect(getByTestId('title').textContent).toEqual('Claim #100150');
     expect(getByTestId('use').textContent).toEqual('complete');
     expect(getByTestId('type').textContent).toContain('oral');
-    expect(getByTestId('created').textContent).toEqual('2014-08-16');
+    expect(getByTestId('created').textContent).toEqual('8/16/2014');
     expect(getByTestId('priority').textContent).toContain('normal');
     expect(getByTestId('insurer').textContent).toEqual('Organization/2');
     expect(getByTestId('payee.type').textContent).toContain('provider');
@@ -112,7 +112,7 @@ describe('should render the Claim component properly', () => {
     };
     const { getByTestId } = render(<Claim {...defaultProps} />);
 
-    expect(getByTestId('accident.date').textContent).toEqual('2014-07-09');
+    expect(getByTestId('accident.date').textContent).toEqual('7/9/2014');
     expect(getByTestId('accident.type').textContent).toContain(
       'Sporting Accident',
     );
@@ -151,7 +151,7 @@ describe('should render the Claim component properly', () => {
     const { getByTestId } = render(<Claim {...defaultProps} />);
 
     expect(getByTestId('employmentImpacted').textContent).toEqual(
-      '2014-08-16 - 2014-08-16',
+      '8/16/2014 - 8/16/2014',
     );
   });
 
@@ -163,7 +163,7 @@ describe('should render the Claim component properly', () => {
     const { getByTestId } = render(<Claim {...defaultProps} />);
 
     expect(getByTestId('hospitalization').textContent).toEqual(
-      '2014-08-15 - 2014-08-16',
+      '8/15/2014 - 8/16/2014',
     );
   });
 
@@ -251,7 +251,7 @@ describe('should render the Claim component properly', () => {
     expect(getByTestId('title').textContent).toEqual('Claim #100150');
     expect(getByTestId('use').textContent).toEqual('claim');
     expect(getByTestId('type').textContent).toContain('oral');
-    expect(getByTestId('created').textContent).toEqual('2014-08-16');
+    expect(getByTestId('created').textContent).toEqual('8/16/2014');
     expect(getByTestId('priority').textContent).toContain('normal');
     expect(getByTestId('insurer').textContent).toEqual('Organization/2');
     expect(getByTestId('payee.type').textContent).toContain('provider');

--- a/src/components/resources/ClaimResponse/ClaimResponse.test.js
+++ b/src/components/resources/ClaimResponse/ClaimResponse.test.js
@@ -23,7 +23,7 @@ describe('should render the ClaimResponse component properly', () => {
 
     expect(getByTestId('title').textContent).toEqual('Claim response #R3500');
     expect(getByTestId('outcome').textContent).toEqual('complete');
-    expect(getByTestId('created').textContent).toEqual('2014-08-16');
+    expect(getByTestId('created').textContent).toEqual('8/16/2014');
     expect(getByTestId('disposition').textContent).toEqual(
       'Claim settled as per contract.',
     );
@@ -40,7 +40,7 @@ describe('should render the ClaimResponse component properly', () => {
     expect(
       getByTestId('payment.amount').textContent.replace(nbspRegex, ' '),
     ).toEqual('100.47 USD');
-    expect(getByTestId('payment.date').textContent).toEqual('2014-08-31');
+    expect(getByTestId('payment.date').textContent).toEqual('8/31/2014');
     expect(
       getByTestId('payment.ref').textContent.replace(nbspRegex, ' '),
     ).toEqual('Identifier: 201408-2-1569478');
@@ -76,7 +76,7 @@ describe('should render the ClaimResponse component properly', () => {
 
     expect(getByTestId('title').textContent).toEqual('Claim response #R3500');
     expect(getByTestId('outcome').textContent).toEqual('complete');
-    expect(getByTestId('created').textContent).toEqual('2014-08-16');
+    expect(getByTestId('created').textContent).toEqual('8/16/2014');
     expect(getByTestId('disposition').textContent).toEqual(
       'Claim settled as per contract.',
     );
@@ -93,7 +93,7 @@ describe('should render the ClaimResponse component properly', () => {
     expect(
       getByTestId('payment.amount').textContent.replace(nbspRegex, ' '),
     ).toEqual('100.47 USD');
-    expect(getByTestId('payment.date').textContent).toEqual('2014-08-31');
+    expect(getByTestId('payment.date').textContent).toEqual('8/31/2014');
     expect(
       getByTestId('payment.ref').textContent.replace(nbspRegex, ' '),
     ).toEqual('Identifier: 201408-2-1569478');
@@ -169,7 +169,7 @@ describe('should render the ClaimResponse component properly', () => {
     expect(getByTestId('title').textContent).toEqual('Claim response #R3500');
     expect(getByTestId('status').textContent).toEqual('active');
     expect(queryByTestId('outcome')).toBeNull();
-    expect(getByTestId('created').textContent).toEqual('2014-08-16');
+    expect(getByTestId('created').textContent).toEqual('8/16/2014');
     expect(getByTestId('disposition').textContent).toEqual(
       'Claim settled as per contract.',
     );
@@ -189,7 +189,7 @@ describe('should render the ClaimResponse component properly', () => {
     expect(
       getByTestId('payment.amount').textContent.replace(nbspRegex, ' '),
     ).toEqual('100.47 USD');
-    expect(getByTestId('payment.date').textContent).toEqual('2014-08-31');
+    expect(getByTestId('payment.date').textContent).toEqual('8/31/2014');
     expect(
       getByTestId('payment.ref').textContent.replace(nbspRegex, ' '),
     ).toEqual('Identifier: 201408-2-1569478');

--- a/src/components/resources/DiagnosticReport/DiagnosticReport.test.js
+++ b/src/components/resources/DiagnosticReport/DiagnosticReport.test.js
@@ -19,12 +19,10 @@ describe('should render component correctly', () => {
     expect(getByTestId('title').textContent).toContain(
       'blood count (hemogram)',
     );
-    expect(getByTestId('effectiveDateTime').textContent).toContain(
-      '2013-04-02',
-    );
+    expect(getByTestId('effectiveDateTime').textContent).toContain('4/2/2013');
 
     expect(getByTestId('categoryCoding').textContent).toContain('Haematology');
-    expect(getByTestId('issued').textContent).toContain('2013-05-15');
+    expect(getByTestId('issued').textContent).toContain('5/15/2013');
     expect(getByTestId('performer').textContent).toContain(
       'University Medical ',
     );
@@ -40,7 +38,7 @@ describe('should render component correctly', () => {
     expect(getByTestId('title').textContent).toContain(
       'blood count (hemogram)',
     );
-    expect(getByTestId('issued').textContent).toContain('2013-05-15');
+    expect(getByTestId('issued').textContent).toContain('5/15/2013');
     expect(getByTestId('categoryCoding').textContent).toContain(
       'Haematology test',
     );
@@ -60,7 +58,7 @@ describe('should render component correctly', () => {
     expect(getByTestId('title').textContent).toContain(
       'blood count (hemogram)',
     );
-    expect(getByTestId('issued').textContent).toContain('2013-05-15');
+    expect(getByTestId('issued').textContent).toContain('5/15/2013');
     expect(getByTestId('categoryCoding').textContent).toContain(
       'Haematology test',
     );
@@ -78,7 +76,7 @@ describe('should render component correctly', () => {
     const { getByTestId } = render(<DiagnosticReport {...defaultProps} />);
 
     expect(getByTestId('title').textContent).toContain('Culture, MRSA');
-    expect(getByTestId('issued').textContent).toContain('2009-08-10');
+    expect(getByTestId('issued').textContent).toContain('8/10/2009');
     expect(getByTestId('categoryCoding').textContent).toContain('(MB)');
 
     expect(getByTestId('performer').textContent).toContain('Todd Ashby');

--- a/src/components/resources/DocumentReference/DocumentReference.test.js
+++ b/src/components/resources/DocumentReference/DocumentReference.test.js
@@ -21,7 +21,7 @@ describe('should render the DocumentReference component properly', () => {
     expect(getByTestId('title').textContent).toEqual('Physical');
     expect(getByTestId('status').textContent).toEqual('current');
     expect(getByTestId('docStatus').textContent).toEqual('preliminary');
-    expect(getByTestId('createdAt').textContent).toEqual('2005-12-24');
+    expect(getByTestId('createdAt').textContent).toEqual('12/24/2005');
     expect(getByTestId('type').textContent.split(nbspRegex)).toEqual([
       'Outpatient Note',
       '(34108-1)',
@@ -70,7 +70,7 @@ describe('should render the DocumentReference component properly', () => {
     expect(getByTestId('title').textContent).toEqual('Physical');
     expect(getByTestId('status').textContent).toEqual('current');
     expect(getByTestId('docStatus').textContent).toEqual('preliminary');
-    expect(getByTestId('createdAt').textContent).toEqual('2005-12-24');
+    expect(getByTestId('createdAt').textContent).toEqual('12/24/2005');
     expect(getByTestId('type').textContent.split(nbspRegex)).toEqual([
       'Outpatient Note',
       '(34108-1)',
@@ -119,7 +119,7 @@ describe('should render the DocumentReference component properly', () => {
     expect(getByTestId('title').textContent).toEqual('Physical');
     expect(getByTestId('status').textContent).toEqual('current');
     expect(queryByTestId('docStatus')).toBeNull();
-    expect(getByTestId('createdAt').textContent).toEqual('2005-12-24');
+    expect(getByTestId('createdAt').textContent).toEqual('12/24/2005');
     expect(getByTestId('type').textContent.split(nbspRegex)).toEqual([
       'Outpatient Note',
       '(34108-1)',

--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.test.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.test.js
@@ -110,14 +110,14 @@ describe('should render ExplanationOfBenefit component properly', () => {
     // table 1st row
     expect(tablesContent[1]).toEqual([
       '(1205)',
-      '2014-08-16',
+      '8/16/2014',
       '-',
       `135.57${String.fromCharCode(160)}USD`,
     ]);
     // table 2nd row
     expect(tablesContent[2]).toEqual([
       '(group)',
-      '2014-08-16',
+      '8/16/2014',
       '-',
       `200${String.fromCharCode(160)}USD`,
     ]);
@@ -176,7 +176,7 @@ describe('should render ExplanationOfBenefit component properly', () => {
       'Organization/iAxXvHiphwGGAL48m3B7XXtKlLZg6yXnC1ch84x1up',
     );
     expect(getByTestId('billablePeriod').textContent).toEqual(
-      'From: 2017-01-05; To: 2018-01-05',
+      'From: 1/5/2017; To: 1/5/2018',
     );
     expect(getByTestId('patient').textContent).toEqual(
       'Patient/f56391c2-dd54-b378-46ef-87c1643a2ba0',
@@ -193,7 +193,7 @@ describe('should render ExplanationOfBenefit component properly', () => {
       'clmrecvddate',
     );
     expect(getByTestId('supportingInfo.timingDate').textContent).toEqual(
-      '2017-01-05',
+      '1/5/2017',
     );
 
     const tablesContent = [];

--- a/src/components/resources/Goal/Goal.test.js
+++ b/src/components/resources/Goal/Goal.test.js
@@ -70,7 +70,7 @@ describe('should render Goal component properly', () => {
       'Peter James Chalmers',
     );
 
-    expect(getByTestId('statusDate').textContent).toEqual('2016-02-14');
+    expect(getByTestId('statusDate').textContent).toEqual('2/14/2016');
 
     expect(getByTestId('description').textContent).toEqual(
       'Target weight is 160 to 180 lbs.',

--- a/src/components/resources/Immunization/Immunization.test.js
+++ b/src/components/resources/Immunization/Immunization.test.js
@@ -23,7 +23,7 @@ describe('should render Immunization component properly', () => {
 
     expect(getByTestId('title').textContent).toContain('Fluvax');
 
-    expect(getByTestId('providedDate').textContent).toContain('on 2013-01-10');
+    expect(getByTestId('providedDate').textContent).toContain('on 1/10/2013');
 
     expect(getByTestId('lotNumber').textContent).toContain('AAJN11K');
     expect(getByTestId('lotNumberExpirationDate').textContent).toContain(
@@ -63,7 +63,7 @@ describe('should render Immunization component properly', () => {
 
     expect(getByTestId('title').textContent).toContain('Fluvax');
 
-    expect(getByTestId('providedDate').textContent).toContain('on 2013-01-10');
+    expect(getByTestId('providedDate').textContent).toContain('on 1/10/2013');
 
     expect(getByTestId('lotNumber').textContent).toContain('AAJN11K');
     expect(getByTestId('lotNumberExpirationDate').textContent).toContain(
@@ -97,7 +97,7 @@ describe('should render Immunization component properly', () => {
 
     expect(getByTestId('title').textContent).toContain('Fluvax');
 
-    expect(getByTestId('providedDate').textContent).toContain('on 2013-01-10');
+    expect(getByTestId('providedDate').textContent).toContain('on 1/10/2013');
 
     expect(getByTestId('lotNumber').textContent).toContain('AAJN11K');
     expect(getByTestId('lotNumberExpirationDate').textContent).toContain(
@@ -131,7 +131,7 @@ describe('should render Immunization component properly', () => {
 
     expect(getByTestId('title').textContent).toContain('DTP');
 
-    expect(getByTestId('providedDate').textContent).toContain('on 2013-01-10');
+    expect(getByTestId('providedDate').textContent).toContain('on 1/10/2013');
 
     expect(getByTestId('patient').textContent).toEqual('Patient/example');
 

--- a/src/components/resources/List/List.test.js
+++ b/src/components/resources/List/List.test.js
@@ -25,7 +25,7 @@ describe('should render List component properly', () => {
     expect(getByTestId('identifier').textContent).toContain('23974652');
     expect(getByTestId('mode').textContent).toContain('changes');
     expect(getByTestId('subject').textContent).toContain('Patient/example');
-    expect(getByTestId('date').textContent).toContain('2012-11-25');
+    expect(getByTestId('date').textContent).toContain('11/25/2012');
     expect(queryByTestId('code')).toBeNull();
     expect(getByTestId('source').textContent).toContain('Patient/example');
     expect(getByTestId('entries')).not.toBeNull();
@@ -45,7 +45,7 @@ describe('should render List component properly', () => {
 
     expect(getByTestId('identifier').textContent).toContain('test');
     expect(getByTestId('mode').textContent).toContain('snapshot');
-    expect(getByTestId('date').textContent).toContain('2015-06-12');
+    expect(getByTestId('date').textContent).toContain('6/12/20');
     expect(getByTestId('entries')).not.toBeNull();
     expect(queryByTestId('usdfExtensions')).toBeNull();
   });
@@ -64,7 +64,7 @@ describe('should render List component properly', () => {
 
     expect(getByTestId('identifier').textContent).toContain('test');
     expect(getByTestId('mode').textContent).toContain('snapshot');
-    expect(getByTestId('date').textContent).toContain('2015-06-12');
+    expect(getByTestId('date').textContent).toContain('6/12/2015');
     expect(getByTestId('entries')).not.toBeNull();
 
     expect(queryByTestId('usdfExtensions')).not.toBeNull();

--- a/src/components/resources/MedicationAdministration/MedicationAdministration.test.js
+++ b/src/components/resources/MedicationAdministration/MedicationAdministration.test.js
@@ -30,9 +30,9 @@ describe('should render MedicationAdministration component properly', () => {
       'Practitioner/example',
     );
 
-    expect(getByTestId('periodTimeStart').textContent).toEqual('2015-01-15');
+    expect(getByTestId('periodTimeStart').textContent).toEqual('1/15/2015');
 
-    expect(getByTestId('periodTimeEnd').textContent).toEqual('2015-01-15');
+    expect(getByTestId('periodTimeEnd').textContent).toEqual('1/15/2015');
 
     expect(getByTestId('dosageRoute').textContent).toContain(
       'Intravenous route',
@@ -58,7 +58,7 @@ describe('should render MedicationAdministration component properly', () => {
 
     expect(getByTestId('practitioner').textContent).toContain('Patrick Pump');
 
-    expect(getByTestId('periodTimeStart').textContent).toEqual('2015-01-15');
+    expect(getByTestId('periodTimeStart').textContent).toEqual('1/15/2015');
 
     expect(getByTestId('periodTimeEnd').textContent).toEqual('-');
 
@@ -83,8 +83,8 @@ describe('should render MedicationAdministration component properly', () => {
     expect(getByTestId('status').textContent).toContain('on-hold');
     expect(getByTestId('patient').textContent).toContain('Donald Duck');
     expect(queryByTestId('practitioner')).toBeNull();
-    expect(getByTestId('periodTimeStart').textContent).toEqual('2015-01-15');
-    expect(getByTestId('periodTimeEnd').textContent).toEqual('2015-01-15');
+    expect(getByTestId('periodTimeStart').textContent).toEqual('1/15/2015');
+    expect(getByTestId('periodTimeEnd').textContent).toEqual('1/15/2015');
     expect(getByTestId('dosageRoute').textContent).toContain('-');
     expect(getByTestId('dosageQuantity').textContent).toEqual('-');
   });
@@ -103,8 +103,8 @@ describe('should render MedicationAdministration component properly', () => {
     expect(getByTestId('status').textContent).toContain('completed');
     expect(getByTestId('patient').textContent).toContain('Donald Duck');
     expect(getByTestId('practitioner').textContent).toContain('Patrick Pump');
-    expect(getByTestId('periodTimeStart').textContent).toEqual('2015-01-15');
-    expect(getByTestId('periodTimeEnd').textContent).toEqual('2015-01-15');
+    expect(getByTestId('periodTimeStart').textContent).toEqual('1/15/2015');
+    expect(getByTestId('periodTimeEnd').textContent).toEqual('1/15/2015');
     expect(getByTestId('dosageRoute').textContent).toContain('Oral Route');
     expect(getByTestId('dosageQuantity').textContent).toEqual('2 TAB');
   });

--- a/src/components/resources/MedicationDispense/MedicationDispense.test.js
+++ b/src/components/resources/MedicationDispense/MedicationDispense.test.js
@@ -21,7 +21,7 @@ describe('should render Device component properly', () => {
 
     expect(getByTestId('title').textContent).toEqual('prescribed medication');
     expect(getByTestId('typeCoding').textContent).toContain('Part Fill');
-    expect(getByTestId('whenPrepared').textContent).toContain('2015-03-01');
+    expect(getByTestId('whenPrepared').textContent).toContain('3/1/2015');
     expect(getByTestId('hasDosageInstruction').textContent).toContain(
       'or after food',
     );
@@ -60,7 +60,7 @@ describe('should render Device component properly', () => {
     expect(container).not.toBeNull();
 
     expect(getByTestId('title').textContent).toContain('Novolog 100u/ml');
-    expect(getByTestId('whenPrepared').textContent).toEqual('2015-01-15');
+    expect(getByTestId('whenPrepared').textContent).toEqual('1/15/2015');
     expect(
       within(getByTestId('hasDosageInstruction'))
         .queryAllByTestId('dosageTiming')

--- a/src/components/resources/MedicationRequest/MedicationRequest.test.js
+++ b/src/components/resources/MedicationRequest/MedicationRequest.test.js
@@ -28,7 +28,7 @@ describe('should render MedicationRequest component properly', () => {
       'Take one tablet',
     );
     expect(getByTestId('requester').textContent).toContain('Patrick Pump');
-    expect(getByTestId('created').textContent).toEqual('2015-03-01');
+    expect(getByTestId('created').textContent).toEqual('3/1/2015');
     expect(getByTestId('intent').textContent).toEqual('order');
   });
   it('should render with STU3 source data in which medicationReference key does not exist', () => {
@@ -59,7 +59,7 @@ describe('should render MedicationRequest component properly', () => {
       'Take one tablet',
     );
     expect(getByTestId('requester').textContent).toContain('Patrick Pump');
-    expect(getByTestId('created').textContent).toEqual('2015-03-01');
+    expect(getByTestId('created').textContent).toEqual('3/1/2015');
     expect(getByTestId('intent').textContent).toEqual('order');
   });
 
@@ -79,7 +79,7 @@ describe('should render MedicationRequest component properly', () => {
       'Take 4 tablets daily',
     );
     expect(getByTestId('requester').textContent).toContain('Patrick Pump');
-    expect(getByTestId('created').textContent).toEqual('2015-01-15');
+    expect(getByTestId('created').textContent).toEqual('1/15/2015');
     expect(getByTestId('intent').textContent).toEqual('order');
   });
 
@@ -101,7 +101,7 @@ describe('should render MedicationRequest component properly', () => {
       '6 mg PO daily for remission',
     );
     expect(getByTestId('requester').textContent).toContain('Patrick Pump');
-    expect(getByTestId('created').textContent).toEqual('2015-01-15');
+    expect(getByTestId('created').textContent).toEqual('1/15/2015');
     expect(getByTestId('intent').textContent).toEqual('order');
   });
 });

--- a/src/components/resources/Observation/Observation.test.js
+++ b/src/components/resources/Observation/Observation.test.js
@@ -62,7 +62,7 @@ describe('should render component correctly', () => {
     );
     expect(getByTestId('status').textContent).toEqual('final');
     expect(getByTestId('secondaryStatus').textContent).toEqual('YES');
-    expect(getByTestId('issuedOn').textContent).toEqual('2016-05-18');
+    expect(getByTestId('issuedOn').textContent).toEqual('5/18/2016');
     expect(getByTestId('subject').textContent).toContain('Patient/infant');
     expect(queryByText(/373066001/g)).not.toBeNull();
   });

--- a/src/components/resources/Patient/Patient.test.js
+++ b/src/components/resources/Patient/Patient.test.js
@@ -87,6 +87,6 @@ describe('should render component correctly', () => {
       fhirResource: example3PatientR4,
     };
     const { getByTestId } = render(<Patient {...defaultProps} />);
-    expect(getByTestId('deceasedInfo').textContent).toEqual('2015-02-14');
+    expect(getByTestId('deceasedInfo').textContent).toEqual('2/14/2015');
   });
 });

--- a/src/components/resources/Practitioner/Practitioner.test.js
+++ b/src/components/resources/Practitioner/Practitioner.test.js
@@ -69,7 +69,7 @@ describe('Practitioner should render component correctly', () => {
     expect(getByTestId('gender').textContent).toEqual('male');
     expect(getByTestId('address').textContent).toContain('Galapagosweg 91');
     expect(getByTestId('telecom').textContent).toContain('phone0205569336');
-    expect(getByTestId('birthDate').textContent).toContain('1979-04-29');
+    expect(getByTestId('birthDate').textContent).toContain('4/29/1979');
   });
 
   it('component without fhirVersion props', () => {

--- a/src/components/resources/Procedure/Procedure.test.js
+++ b/src/components/resources/Procedure/Procedure.test.js
@@ -57,9 +57,7 @@ describe('Procedure should render component correctly', () => {
       'Insertion of intracardiac pacemaker (procedure)',
     );
     expect(getByTestId('status').textContent).toEqual('completed');
-    expect(getByTestId('performedDateTime').textContent).toEqual(
-      'on 4/5/2015',
-    );
+    expect(getByTestId('performedDateTime').textContent).toEqual('on 4/5/2015');
     expect(getByTestId('hasCoding').textContent).toContain(
       'Insertion of intracardiac',
     );

--- a/src/components/resources/Procedure/Procedure.test.js
+++ b/src/components/resources/Procedure/Procedure.test.js
@@ -58,7 +58,7 @@ describe('Procedure should render component correctly', () => {
     );
     expect(getByTestId('status').textContent).toEqual('completed');
     expect(getByTestId('performedDateTime').textContent).toEqual(
-      'on 2015-04-05',
+      'on 4/5/2015',
     );
     expect(getByTestId('hasCoding').textContent).toContain(
       'Insertion of intracardiac',

--- a/src/components/resources/Questionnaire/Questionnaire.test.js
+++ b/src/components/resources/Questionnaire/Questionnaire.test.js
@@ -58,7 +58,7 @@ describe('Questionnaire should render component correctly', () => {
       'Cancer Quality Forum Questionnaire',
     );
     expect(getByTestId('status').textContent).toEqual('draft');
-    expect(getByTestId('dateTime').textContent).toEqual('2012-01');
+    expect(getByTestId('dateTime').textContent).toEqual('January 2012');
 
     // contain id and test of questions of subgroup
     expect(String(getByTestId('linkId-1.1').textContent).trim()).toContain(
@@ -119,7 +119,7 @@ describe('Questionnaire should render component correctly', () => {
       'Cancer Quality Forum Questionnaire',
     );
     expect(getByTestId('status').textContent).toEqual('draft');
-    expect(getByTestId('dateTime').textContent).toEqual('2012-01');
+    expect(getByTestId('dateTime').textContent).toEqual('January 2012');
 
     // contain id and test of questions of subgroup
     expect(String(getByTestId('linkId-1.1').textContent).trim()).toContain(
@@ -180,7 +180,7 @@ describe('Questionnaire should render component correctly', () => {
       'Cancer Quality Forum Questionnaire',
     );
     expect(getByTestId('status').textContent).toEqual('draft');
-    expect(getByTestId('dateTime').textContent).toEqual('2012-01');
+    expect(getByTestId('dateTime').textContent).toEqual('January 2012');
 
     // contain id and test of questions of subgroup
     expect(String(getByTestId('linkId-1.1').textContent).trim()).toContain(

--- a/src/components/resources/QuestionnaireResponse/QuestionnaireResponse.test.js
+++ b/src/components/resources/QuestionnaireResponse/QuestionnaireResponse.test.js
@@ -23,7 +23,7 @@ describe('QuestionnaireResponse should render component correctly', () => {
       'Questionnaire Response',
     );
     expect(getByTestId('status').textContent).toEqual('completed');
-    expect(getByTestId('dateTime').textContent).toEqual('2013-06-18');
+    expect(getByTestId('dateTime').textContent).toEqual('6/18/2013');
     expect(getByTestId('subject').textContent).toEqual('RoelPatient/f201');
     expect(getByTestId('author').textContent).toEqual('Practitioner/f201');
 
@@ -34,7 +34,7 @@ describe('QuestionnaireResponse should render component correctly', () => {
       'What is your gender?Male ',
     );
     expect(getByTestId('linkId-2.2').textContent).toEqual(
-      'What is your date of birth?1960-03-13 ',
+      'What is your date of birth?3/13/1960 ',
     );
     expect(getByTestId('linkId-2.3').textContent).toEqual(
       'What is your country of birth?The Netherlands ',
@@ -56,7 +56,7 @@ describe('QuestionnaireResponse should render component correctly', () => {
       'Glasgow Coma Score',
     );
     expect(getByTestId('status').textContent).toEqual('completed');
-    expect(getByTestId('dateTime').textContent).toEqual('2014-12-11');
+    expect(getByTestId('dateTime').textContent).toEqual('12/11/2014');
 
     expect(getByTestId('linkId-1.1').textContent).toContain('(LA6560-2) ');
   });
@@ -72,7 +72,7 @@ describe('QuestionnaireResponse should render component correctly', () => {
       'Questionnaire Response',
     );
     expect(getByTestId('status').textContent).toEqual('completed');
-    expect(getByTestId('dateTime').textContent).toEqual('2013-02-19');
+    expect(getByTestId('dateTime').textContent).toEqual('2/19/2013');
 
     expect(getByTestId('answer-nameOfChild-0').textContent).toContain(
       'Cathy Jones',
@@ -90,7 +90,7 @@ describe('QuestionnaireResponse should render component correctly', () => {
       'Questionnaire Response',
     );
     expect(getByTestId('status').textContent).toEqual('completed');
-    expect(getByTestId('dateTime').textContent).toEqual('2013-06-18');
+    expect(getByTestId('dateTime').textContent).toEqual('6/18/2013');
     expect(getByTestId('subject').textContent).toEqual('RoelPatient/f201');
     expect(getByTestId('author').textContent).toEqual('Practitioner/f201');
 

--- a/src/components/resources/ReferralRequest/ReferralRequest.test.js
+++ b/src/components/resources/ReferralRequest/ReferralRequest.test.js
@@ -21,7 +21,7 @@ describe('should render ReferralRequest component properly', () => {
     expect(getByTestId('typeCoding').textContent).toContain(
       'Referral for service',
     );
-    expect(getByTestId('dateSent').textContent).toContain('2014-02-14');
+    expect(getByTestId('dateSent').textContent).toContain('2/14/2014');
     expect(getByTestId('reason').textContent).toContain(
       'For consideration of Grommets',
     );
@@ -46,7 +46,7 @@ describe('should render ReferralRequest component properly', () => {
     expect(getByTestId('typeCoding').textContent).toContain(
       'Patient referral to specialist',
     );
-    expect(getByTestId('dateSent').textContent).toContain('2014-02-14');
+    expect(getByTestId('dateSent').textContent).toContain('2/14/2014');
     expect(getByTestId('reason').textContent).toContain(
       'For consideration of Grommets',
     );

--- a/src/components/resources/ResearchStudy/ResearchStudy.test.js
+++ b/src/components/resources/ResearchStudy/ResearchStudy.test.js
@@ -48,7 +48,7 @@ describe('should render ResearchStudy component properly', () => {
 
     expect(title).toEqual('Example study');
     expect(status).toEqual('completed');
-    expect(period).toEqual('2015-02-01 - 2015-02-21');
+    expect(period).toEqual('2/1/2015 - 2/21/2015');
     expect(category).toEqual('Gene expression (GENE)');
     expect(focus).toEqual('Prostate cancer (PRC)');
     expect(protocol).toEqual('PlanDefinition/pdf1');

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -1,5 +1,21 @@
 export const formatDate = (date, locale) => {
   const rawDate = new Date(date);
-  const usDate = rawDate.toLocaleDateString(locale);
+  const usDate = rawDate.toLocaleDateString(locale, whichOptions(date));
   return usDate;
+};
+
+const whichOptions = date => {
+  const YEAR_FORMAT = 'YYYY';
+  const YEAR_MONTH_FORMAT = 'YYYY-MM';
+
+  if (date.length === YEAR_FORMAT.length) {
+    return { year: 'numeric' };
+  }
+  if (date.length <= YEAR_MONTH_FORMAT.length) {
+    return {
+      year: 'numeric',
+      month: 'long',
+    };
+  }
+  return;
 };

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -1,0 +1,5 @@
+export const formatDate = (date, locale) => {
+  const rawDate = new Date(date);
+  const usDate = rawDate.toLocaleDateString(locale);
+  return usDate;
+};

--- a/src/utils/formatDate.test.js
+++ b/src/utils/formatDate.test.js
@@ -1,0 +1,22 @@
+import { formatDate } from './formatDate';
+
+describe('Date format function', () => {
+  const locale = 'en-US';
+
+  it('should return year', () => {
+    const date = '2021';
+    expect(formatDate(date, locale)).toEqual('2021');
+  });
+  it('should return US month and year', () => {
+    const date = '2021-03';
+    expect(formatDate(date, locale)).toEqual('March 2021');
+  });
+  it('should return US date format', () => {
+    const date = '2021-03-14';
+    expect(formatDate(date, locale)).toEqual('3/14/2021');
+  });
+  it('should return US date format given full timestamp', () => {
+    const date = '2021-03-14T13:28:17-05:00';
+    expect(formatDate(date, locale)).toEqual('3/14/2021');
+  });
+});


### PR DESCRIPTION
[#71](https://app.zenhub.com/workspaces/patient-app-6140de7e31081800158d8ecf/issues/1uphealth/patient/71)
Issue:  Date component displaying US date format in accordance to the design

---

<!-- Complete these steps to start getting this PR reviewed -->
##### PR Checklist
- [x] Give this PR a meaningful title
- [x] Add a link to the related issue at the top of this description (above)
- [x] Connect this PR with the related issue via ZenHub with the button below this text box (or at the bottom of the page after the PR is created)
- [x] Ensure your branch is up to date with the target branch and resolve any conflicts
- [x] Answer the below questions to describe your PR for reviewers
- [x] Request at least two reviewers using the "Reviewers" section on the right, usually including at least one reviewer from your team
- [x] Notify the requested reviewers in the #code-review Slack channel once the PR is ready for review

---

<!-- Answer these questions to describe the PR for reviewers -->

## Why are these changes needed?
<!-- Give context for reviewers who might not be familiar with the issue -->
The Date component displays dates as the are fetched from the data source in a format resembling a timestamp. This is not in alignment with the new design (US format) 


## What changed?
Additional helper function was implemented which does that


## How are these changes tested?
<!-- Explain how you verified these changes (unit/integration tests? manual verification?) and describe how the reviewers can verify the changes themselves (how to run the tests, what to look for in manual checks) - including regression of existing code (e.g. do all previously existing unit tests still pass?) -->
Date (atomic component) is used in many storybook components and the changes were tested visually. Also unit tests of the said components were updated to test against US format. Additional unit tests were created for the helper function.
