### PR TITLE
Add bootstrap framework to replace the current hardcoded styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "react": "^17.0.1"
   },
   "dependencies": {
+    "bootstrap": "^5.1.1",
     "dompurify": "^2.0.7",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "react": "^17.0.1"
   },
   "dependencies": {
+    "@popperjs/core": "^2.10.2",
     "bootstrap": "^5.1.1",
     "dompurify": "^2.0.7",
     "lodash": "^4.17.15",

--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,8 @@ import './style.css';
 import FhirResource from './components/containers/FhirResource';
 import fhirVersions from './components/resources/fhirResourceVersions';
 
-let BootstrapLibrary;
 if (typeof document !== 'undefined') {
-  BootstrapLibrary = require('bootstrap/dist/js/bootstrap.min.js').default;
+  require('bootstrap/dist/js/bootstrap.min.js');
 }
 
 export { FhirResource, fhirVersions };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,13 @@
+import 'bootstrap/dist/css/bootstrap.min.css';
+import './style.css';
+
 import FhirResource from './components/containers/FhirResource';
 import fhirVersions from './components/resources/fhirResourceVersions';
 
-import './style.css';
+let BootstrapLibrary;
+if (typeof document !== 'undefined') {
+  BootstrapLibrary = require('bootstrap/dist/js/bootstrap.min.js').default;
+}
 
 export { FhirResource, fhirVersions };
 export * from './components/supportedFhirResourceList';


### PR DESCRIPTION
<!-- Add a link to the related issue here, e.g. #1234 -->
Issue:  [#27](https://app.zenhub.com/workspaces/patient-app-6140de7e31081800158d8ecf/issues/1uphealth/patient/27)

---

<!-- Complete these steps to start getting this PR reviewed -->
##### PR Checklist
- [X] Give this PR a meaningful title
- [X] Add a link to the related issue at the top of this description (above)
- [ ] Connect this PR with the related issue via ZenHub with the button below this text box (or at the bottom of the page after the PR is created)
- [ ] Ensure your branch is up to date with the target branch and resolve any conflicts
- [X] Answer the below questions to describe your PR for reviewers
- [ ] Request at least two reviewers using the "Reviewers" section on the right, usually including at least one reviewer from your team
- [ ] Notify the requested reviewers in the #code-review Slack channel once the PR is ready for review

---

<!-- Answer these questions to describe the PR for reviewers -->

## Why are these changes needed?
Bootstrap classes are intended to replace existing styles stored currently in css files.  For this reason, it was necessary to add bootstrap to the project in order to use its classes while working on future tasks.

## What changed?
Added two new dependencies: `bootstrap` and `popperjs/core`. Added bootstrap imports in the index.js file.

## How are these changes tested?
The application was checked locally. The `FHIR-React` library has been linked locally to the `Patient` application. Checked the behaviour of library components with styles added using bootstrap classes. It has been confirmed that it is possible for a developer who uses the library to override bootstrap classes by using styles in CSS files.
