### PR TITLE
Publishes to npm registry whenever a release is made

### DIFF
--- a/.github/workflows/publish_npmjs.yml
+++ b/.github/workflows/publish_npmjs.yml
@@ -1,0 +1,18 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -196,9 +196,7 @@ npm run build
 
 ### Publish to NPM Registry
 
-```
-npm publish
-```
+To publish, [create a new release in GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).
 
 ### Storybook for the changes
 


### PR DESCRIPTION
This PR creates a GitHub action to publish a version to NPMjs.com whenever a release is made on GitHub. 

GitHub reference: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages

