### PR TITLE
Fix NPM Publish

### DIFF
--- a/.github/workflows/publish_npmjs.yml
+++ b/.github/workflows/publish_npmjs.yml
@@ -13,6 +13,8 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+      - run: npm run build
+      - run: npm run test
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ export default {
 | `ReferralRequest`          |  ✅   |  ✅   | _N/A_ |
 | `ResearchStudy`            | _N/A_ |  ✅   |  ✅   |
 
-### Styles update `v0.3.0`
+### Styles update `v0.3`
 
-The 0.3.0 version of the FHIR React Component library introduces the bootstrap Accordion component as the base of each available resource which provides any data. The RWD support is provided for each component.
+The 0.3 version of the FHIR React Component library introduces the bootstrap Accordion component as the base of each available resource which provides any data. The RWD support is provided for each component.
 
 All of the changes can be tracked by viewing the current version of the [storybook](https://fhir-react-lib-test-storybook.s3.amazonaws.com/branch/fhir-react-next/index.html?path=/story/condition--default-visualization-dstu-2).
 
-### Available resources `v0.3.0`
+### Available resources `v0.3`
 
 
 | Resource                   | DSTU2 | STU3  |  R4   | Carin BB Profile | DaVinci PDex |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fhir-react",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fhir-react",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "@nivo/core": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-react",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "React component library for displaying FHIR Resources ",
   "main": "build/index.js",
   "peerDependencies": {


### PR DESCRIPTION
The first attempt at using GitHub actions for publishing to NPM didn't build the project or run tests. This PR adds both, and bumps the version to 0.3.1 to indicate the fix.

After this PR is merged, will create 0.3.1 release to deploy fix to npmjs.com.