### PR TITLE
Fix sass, svg loading & headerIcon condition (v0.3.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CircleCI](https://circleci.com/gh/1uphealth/fhir-react/tree/master.svg?style=svg)](https://circleci.com/gh/1uphealth/fhir-react/tree/master)
-[![Storybook](https://github.com/storybookjs/brand/raw/master/badge/badge-storybook.svg?sanitize=true)](http://storybook-fhir-react-lib.s3-website-us-east-1.amazonaws.com/)
+[![Storybook](https://github.com/storybookjs/brand/raw/master/badge/badge-storybook.svg?sanitize=true)](https://fhir-react-lib-test-storybook.s3.amazonaws.com/branch/fhir-react-next/index.html)
 
 # fhir-react
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fhir-react",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fhir-react",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "@nivo/core": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-react",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "React component library for displaying FHIR Resources ",
   "main": "build/index.js",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "md5": "^2.2.1",
     "pretty-bytes": "^5.3.0",
     "prop-types": "^15.7.2",
-    "react": "^17.0.1"
+    "react": "^17.0.1",
+    "svg-url-loader": "^7.1.1"
   },
   "scripts": {
     "test": "NODE_ENV=test jest",

--- a/src/components/resources/Condition/Condition.js
+++ b/src/components/resources/Condition/Condition.js
@@ -101,7 +101,8 @@ function Condition(props) {
     dateRecorded,
   } = resourceDTO(fhirVersion, fhirResource);
 
-  const headerIcon = fhirIcons[_get(fhirResource, 'resourceType')];
+  const headerIcon = fhirIcons && fhirIcons[_get(fhirResource, 'resourceType')];
+
   const tableData = [
     {
       label: 'Asserted by',

--- a/src/components/resources/Immunization/Immunization.js
+++ b/src/components/resources/Immunization/Immunization.js
@@ -125,7 +125,7 @@ const Immunization = props => {
     note,
   } = resourceDTO(fhirVersion, fhirResource);
 
-  const headerIcon = fhirIcons[_get(fhirResource, 'resourceType')];
+  const headerIcon = fhirIcons && fhirIcons[_get(fhirResource, 'resourceType')];
   const tableData = [
     {
       label: 'Manufacturer Text',

--- a/src/components/resources/Procedure/Procedure.js
+++ b/src/components/resources/Procedure/Procedure.js
@@ -37,7 +37,7 @@ const Procedure = props => {
   const note = _get(fhirResource, 'note', []);
   const outcome = _get(fhirResource, 'outcome');
 
-  const headerIcon = fhirIcons[_get(fhirResource, 'resourceType')];
+  const headerIcon = fhirIcons && fhirIcons[_get(fhirResource, 'resourceType')];
   const tableData = [
     {
       label: 'Identification',

--- a/src/components/resources/ResourceCategory/ResourceCategory.js
+++ b/src/components/resources/ResourceCategory/ResourceCategory.js
@@ -13,7 +13,7 @@ const ResourceCategory = props => {
   const getItemsCountLabel = () =>
     `${parsedItemsCount} ${parsedItemsCount === 1 ? 'item' : 'items'}`;
 
-  const headerIcon = fhirIcons['ResourceCategoryPlaceholder'];
+  const headerIcon = fhirIcons && fhirIcons['ResourceCategoryPlaceholder'];
   const parsedItemsCount = parseNumber(itemsCount);
 
   return (

--- a/src/components/resources/ResourceCategory/ResourceCategory.js
+++ b/src/components/resources/ResourceCategory/ResourceCategory.js
@@ -12,7 +12,7 @@ const ResourceCategory = props => {
   const getItemsCountLabel = () =>
     `${parsedItemsCount} ${parsedItemsCount === 1 ? 'item' : 'items'}`;
 
-  const headerIcon = fhirIcons && fhirIcons['ResourceCategoryPlaceholder'];
+  const headerIcon = fhirIcons && fhirIcons['ResourceCategory'];
   const parsedItemsCount = parseNumber(itemsCount);
 
   return (

--- a/src/components/resources/ResourceCategory/ResourceCategory.js
+++ b/src/components/resources/ResourceCategory/ResourceCategory.js
@@ -1,5 +1,4 @@
 import { Root, Title } from '../../ui';
-import ChevronRight from '../../../assets/common/chevron-right.svg';
 import HeaderIcon from '../../datatypes/HeaderIcon';
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -38,7 +37,7 @@ const ResourceCategory = props => {
             </div>
           )}
           <img
-            src={ChevronRight}
+            src={require('../../../assets/common/chevron-right.svg')}
             alt="chevron"
             style={{ height: 28, width: 28 }}
           />

--- a/src/components/resources/ResourceCategory/ResourceCategory.test.js
+++ b/src/components/resources/ResourceCategory/ResourceCategory.test.js
@@ -5,7 +5,7 @@ import fhirIcons from '../../../fixtures/example-icons';
 import ResourceCategory from './ResourceCategory';
 
 describe('should render ResourceCategory component properly', () => {
-  const placeholderResource = fhirIcons['ResourceCategoryPlaceholder'].props;
+  const placeholderResource = fhirIcons['ResourceCategory'].props;
 
   it('should render ResourceCategory component with icon and itemsCount > 1 correctly', () => {
     const defaultProps = {

--- a/src/components/supportedFhirResourceList.js
+++ b/src/components/supportedFhirResourceList.js
@@ -37,6 +37,7 @@ import Questionnaire from './resources/Questionnaire';
 import QuestionnaireResponse from './resources/QuestionnaireResponse';
 import ReferralRequest from './resources/ReferralRequest';
 import ResearchStudy from './resources/ResearchStudy';
+import ResourceCategory from './resources/ResourceCategory';
 
 export {
   Appointment,
@@ -78,4 +79,5 @@ export {
   QuestionnaireResponse,
   ReferralRequest,
   ResearchStudy,
+  ResourceCategory,
 };

--- a/src/fixtures/example-icons.jsx
+++ b/src/fixtures/example-icons.jsx
@@ -160,7 +160,7 @@ export default {
       alt="finger pointing something in a book"
     />
   ),
-  ResourceCategoryPlaceholder: (
+  ResourceCategory: (
     <img
       src={require('../assets/containers/ResourceCategory/resource-placeholder.svg')}
       alt="header icon"

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './style.css';
+import './style.scss';
 
 import FhirResource from './components/containers/FhirResource';
 import fhirVersions from './components/resources/fhirResourceVersions';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = {
         },
       },
       {
-        test: /\.css$/,
+        test: /\.(css|scss)$/,
         exclude: path.resolve(
           __dirname,
           'src/components/ui/bootstrap-reboot.min.css',
@@ -35,6 +35,7 @@ module.exports = {
             loader: MiniCssExtractPlugin.loader,
           },
           'css-loader',
+          'sass-loader',
         ],
       },
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,14 @@ module.exports = {
           'sass-loader',
         ],
       },
+      {
+        test: /\.svg$/,
+        use: [
+          {
+            loader: 'svg-url-loader',
+          },
+        ],
+      },
     ],
   },
   externals: {


### PR DESCRIPTION

## Why are these changes needed?
This PR includes the changes, which are needed to properly connect the new version of FHIR React Component library with the Patient App.

## What changed?
_**Change 1.**_ While connecting the new version of the fhir-react library, we noticed that styles from `.scss` files do not apply to components used in the Patient App. For this reason, I added the `sass-loader` in `webpack.config.js` file. 

_**Change 2.**_ Adding `svg-loader` in `webpack.config.js` was necessary to properly load SVG icon in ResourceCategory or Header components

_**Change 3.**_ We got errors while rendering some of the new resources in the Patient App due to the incorrect condition in the HeaderIcon component. Now before loading any icon in the component, we check if the resource has obtained the correct dataset.

## How are these changes tested?
All of the changes were tested in the Patient App with a locally linked FHIR React Component library. (releasing 0.3.2 version will introduce these changes to the official npm repository)

As you can see on the screenshot, styles from the latest version of the FHIR React Component library were not applied globally. Example from the Patient component:

- Before:

<img width="1562" alt="Zrzut ekranu 2021-12-16 o 20 05 33" src="https://user-images.githubusercontent.com/86961707/146433089-6d6e1f02-311e-4c4a-9436-420f375dc147.png">

- After:

<img width="1553" alt="Zrzut ekranu 2021-12-16 o 20 02 23" src="https://user-images.githubusercontent.com/86961707/146432975-e196c511-b3c1-4b5a-9f50-150cf3acb938.png">