### PR TITLE
[PATIENT-1] fixed datePeriod display; fixed supportingInfo display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-react",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "React component library for displaying FHIR Resources ",
   "main": "build/index.js",
   "peerDependencies": {

--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
@@ -512,7 +512,7 @@ const ExplanationOfBenefit = props => {
                       );
                       const infoStatus = _get(informationItem, infoKey);
                       const StatusComponent =
-                        infoKey == 'timingDate' ? Date : Quantity;
+                        infoKey.toString() === 'timingDate' ? Date : Quantity;
 
                       return (
                         <TableRow key={`serviceItem-${i}`}>

--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
@@ -529,7 +529,7 @@ const ExplanationOfBenefit = props => {
                               infoKey === 'timingDate' ? (
                                 <Date fhirData={infoStatus} />
                               ) : (
-                                <div>{infoStatus}</div>
+                                <Coding fhirData={infoStatus} />
                               )
                             ) : (
                               <MissingValue />

--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
@@ -14,6 +14,7 @@ import {
 import CareTeam from './CareTeam';
 import CodeableConcept from '../../datatypes/CodeableConcept';
 import Coding from '../../datatypes/Coding';
+import Quantity from '../../datatypes/Quantity';
 import Date from '../../datatypes/Date';
 import Diagnosis from './Diagnosis';
 import Identifier from '../../datatypes/Identifier/Identifier';
@@ -455,16 +456,12 @@ const ExplanationOfBenefit = props => {
                             <Coding fhirData={serviceItem.coding} />
                           </TableCell>
                           <TableCell data-testid="explanation.servicedDate">
-                            {serviceItem.servicedDate ||
-                            serviceItem.servicedPeriod ? (
-                              serviceItem.servicedDate ? (
-                                <Date fhirData={serviceItem.servicedDate} />
-                              ) : (
+                            {(serviceItem.servicedDate && (
+                              <Date fhirData={serviceItem.servicedDate} />
+                            )) ||
+                              (serviceItem.servicedPeriod && (
                                 <Period fhirData={serviceItem.servicedPeriod} />
-                              )
-                            ) : (
-                              <MissingValue />
-                            )}
+                              )) || <MissingValue />}
                           </TableCell>
                           <TableCell data-testid="explanation.quantity">
                             {Number.isFinite(Number(serviceItem.quantity)) ? (
@@ -514,6 +511,8 @@ const ExplanationOfBenefit = props => {
                         },
                       );
                       const infoStatus = _get(informationItem, infoKey);
+                      const StatusComponent =
+                        infoKey == 'timingDate' ? Date : Quantity;
 
                       return (
                         <TableRow key={`serviceItem-${i}`}>
@@ -526,11 +525,7 @@ const ExplanationOfBenefit = props => {
                           </TableCell>
                           <TableCell>
                             {infoStatus ? (
-                              infoKey === 'timingDate' ? (
-                                <Date fhirData={infoStatus} />
-                              ) : (
-                                <Coding fhirData={infoStatus} />
-                              )
+                              <StatusComponent fhirData={infoStatus} />
                             ) : (
                               <MissingValue />
                             )}

--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
@@ -80,9 +80,10 @@ const stu3DTO = fhirResource => {
     services.map(serviceItem => {
       const coding = _get(serviceItem, 'service.coding.0');
       const servicedDate = _get(serviceItem, 'servicedDate');
+      const servicedPeriod = _get(serviceItem, 'servicedPeriod');
       const quantity = _get(serviceItem, 'quantity.value');
       const itemCost = _get(serviceItem, 'net');
-      return { coding, servicedDate, quantity, itemCost };
+      return { coding, servicedDate, servicedPeriod, quantity, itemCost };
     });
 
   return {
@@ -126,9 +127,10 @@ const r4DTO = fhirResource => {
     services.map(serviceItem => {
       const coding = _get(serviceItem, 'productOrService.coding.0');
       const servicedDate = _get(serviceItem, 'servicedDate');
+      const servicedPeriod = _get(serviceItem, 'servicedPeriod');
       const quantity = _get(serviceItem, 'quantity.value');
       const itemCost = _get(serviceItem, 'net');
-      return { coding, servicedDate, quantity, itemCost };
+      return { coding, servicedDate, servicedPeriod, quantity, itemCost };
     });
 
   return {
@@ -453,8 +455,13 @@ const ExplanationOfBenefit = props => {
                             <Coding fhirData={serviceItem.coding} />
                           </TableCell>
                           <TableCell data-testid="explanation.servicedDate">
-                            {serviceItem.servicedDate ? (
-                              <Date fhirData={serviceItem.servicedDate} />
+                            {serviceItem.servicedDate ||
+                            serviceItem.servicedPeriod ? (
+                              serviceItem.servicedDate ? (
+                                <Date fhirData={serviceItem.servicedDate} />
+                              ) : (
+                                <Period fhirData={serviceItem.servicedPeriod} />
+                              )
                             ) : (
                               <MissingValue />
                             )}
@@ -501,7 +508,12 @@ const ExplanationOfBenefit = props => {
                         informationItem,
                         'category.coding.0',
                       );
-                      const infoStatus = _get(informationItem, 'code.coding.0');
+                      const infoKey = Object.keys(informationItem).filter(
+                        key => {
+                          return key !== 'sequence' && key !== 'category';
+                        },
+                      );
+                      const infoStatus = _get(informationItem, infoKey);
 
                       return (
                         <TableRow key={`serviceItem-${i}`}>
@@ -514,7 +526,11 @@ const ExplanationOfBenefit = props => {
                           </TableCell>
                           <TableCell>
                             {infoStatus ? (
-                              <Coding fhirData={infoStatus} />
+                              infoKey === 'timingDate' ? (
+                                <Date fhirData={infoStatus} />
+                              ) : (
+                                <div>{infoStatus}</div>
+                              )
                             ) : (
                               <MissingValue />
                             )}

--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.test.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.test.js
@@ -200,13 +200,18 @@ describe('should render ExplanationOfBenefit component properly', () => {
       'Condition/88bd5ac6-175b-5906-a4ee-6eedd667b0cc',
     );
     expect(getByTestId('diagnosisType').textContent).toContain('principal');
-    expect(getByTestId('supportingInfo.category').textContent).toContain(
+    expect(getByTestId('supportingInfo.0.category').textContent).toContain(
       'clmrecvddate',
     );
-    expect(getByTestId('supportingInfo.timingDate').textContent).toEqual(
+    expect(getByTestId('supportingInfo.0.timingDate').textContent).toEqual(
       '1/5/2017',
     );
-
+    expect(getByTestId('supportingInfo.1.category').textContent).toContain(
+      'dayssupply',
+    );
+    expect(getByTestId('supportingInfo.1.valueQuantity').textContent).toContain(
+      '30',
+    );
     // checking if text content of each header cell is equal to mocked data
     const headerCells = getAllByRole('columnheader')
       .slice(0, 4)

--- a/src/components/resources/ExplanationOfBenefit/SupportingInfo.js
+++ b/src/components/resources/ExplanationOfBenefit/SupportingInfo.js
@@ -4,6 +4,7 @@ import _get from 'lodash/get';
 import { ValueSection, Value } from '../../ui/index';
 import CodeableConcept from '../../datatypes/CodeableConcept';
 import Date from '../../datatypes/Date';
+import Quantity from '../../datatypes/Quantity';
 
 const SupportingInfo = ({ fhirData }) => {
   return fhirData.map((supportingInfo, index) => {
@@ -11,6 +12,7 @@ const SupportingInfo = ({ fhirData }) => {
     const category = _get(supportingInfo, 'category');
     const code = _get(supportingInfo, 'code	');
     const timingDate = _get(supportingInfo, 'timingDate');
+    const valueQuantity = _get(supportingInfo, 'valueQuantity');
     const timingPeriodStart = _get(supportingInfo, 'timingPeriod.start');
     const timingPeriodEnd = _get(supportingInfo, 'timingPeriod.end');
 
@@ -18,20 +20,24 @@ const SupportingInfo = ({ fhirData }) => {
       <div key={`total-${index}`}>
         <ValueSection
           label={`Supporting information ${sequence}.`}
-          data-testid="supportingInfo"
+          data-testid={`supportingInfo.${index}`}
           marginTop
         >
           {category && (
             <Value
               dirColumn
               label="Category"
-              data-testid="supportingInfo.category"
+              data-testid={`supportingInfo.${index}.category`}
             >
               <CodeableConcept fhirData={category} />
             </Value>
           )}
           {code && (
-            <Value dirColumn label="Code" data-testid="supportingInfo.code">
+            <Value
+              dirColumn
+              label="Code"
+              data-testid={`supportingInfo.${index}.category`}
+            >
               <CodeableConcept fhirData={code} />
             </Value>
           )}
@@ -39,16 +45,25 @@ const SupportingInfo = ({ fhirData }) => {
             <Value
               dirColumn
               label="Date"
-              data-testid="supportingInfo.timingDate"
+              data-testid={`supportingInfo.${index}.timingDate`}
             >
               <Date fhirData={timingDate} />
+            </Value>
+          )}
+          {valueQuantity && (
+            <Value
+              dirColumn
+              label="Quantity"
+              data-testid={`supportingInfo.${index}.valueQuantity`}
+            >
+              <Quantity fhirData={valueQuantity} />
             </Value>
           )}
           {timingPeriodStart && (
             <Value
               dirColumn
               label="Start date"
-              data-testid="supportingInfo.timingPeriodStart"
+              data-testid={`supportingInfo.${index}.timingPeriodStart`}
             >
               <Date fhirData={timingPeriodStart} />
             </Value>
@@ -57,7 +72,7 @@ const SupportingInfo = ({ fhirData }) => {
             <Value
               dirColumn
               label="End date"
-              data-testid="supportingInfo.timingPeriodEnd"
+              data-testid={`supportingInfo.${index}.timingPeriodEnd`}
             >
               <Date fhirData={timingPeriodEnd} />
             </Value>

--- a/src/fixtures/r4/resources/explanationOfBenefit/c4bbExample.json
+++ b/src/fixtures/r4/resources/explanationOfBenefit/c4bbExample.json
@@ -148,13 +148,29 @@
       "category": {
         "coding": [
           {
+            "code": "clmrecvddate",
             "system": "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBSupportingInfoType",
-            "code": "clmrecvddate"
+            "display": "Claim Received Date"
           }
         ]
       },
       "timingDate": "2017-01-05"
-    }
+    },
+    {
+      "sequence": 2,
+      "category": {
+          "coding": [
+              {
+                  "code": "dayssupply",
+                  "system": "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBSupportingInfoType",
+                  "display": "Days Supply"
+              }
+          ]
+      },
+      "valueQuantity": {
+          "value": 30
+      }
+  }
   ],
   "diagnosis": [
     {


### PR DESCRIPTION
<!-- Add a link to the related issue here, e.g. #1234 -->
Issue:  https://1uphealth.atlassian.net/jira/software/projects/PATIENT/boards/4?selectedIssue=PATIENT-1

---
This will make changes to any project using the fhir-react library. Current live patient app will need to be redeployed after this change is published to npm.
<!-- Answer these questions to describe the PR for reviewers -->

## Why are these changes needed?
Customer found display errors based on unsupported keys in the frontend.
<!-- Give context for reviewers who might not be familiar with the issue -->


## What changed?
Services with servicePeriods will now show correctly in the table.
Supporting Info will now show proper status values when in the table.
<!-- Tell reviewers what to expect to see in your changeset, and include screenshots for any front-end/visual changes (do not upload PHI or secrets in screenshots) -->


## How are these changes tested?
<!-- Explain how you verified these changes (unit/integration tests? manual verification?) and describe how the reviewers can verify the changes themselves (how to run the tests, what to look for in manual checks) - including regression of existing code (e.g. do all previously existing unit tests still pass?) -->
Using storybook
Added Jest tests