### PR TITLE
PATIENTAPP-99 Fix bug while opening the Accordion (click on single resource triggered multiple Accordions to open)

### DIFF
--- a/src/components/containers/Accordion/Accordion.js
+++ b/src/components/containers/Accordion/Accordion.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Chevron } from '../../ui';
+import uniqueId from 'lodash/uniqueId';
 
 const CHEVRON_DOWN_COLOR = '#6f83a9';
 const CHEVRON_UP_COLOR = '#2a6fd7';
@@ -8,6 +9,9 @@ const Accordion = props => {
   const { headerContent, bodyContent } = props;
   const [rotate, setRotate] = useState(false);
   const handleAccordionClick = () => setRotate(!rotate);
+  const accordionId = uniqueId(
+    `accordion-type-${headerContent.props.resourceName || 'default'}-`,
+  );
 
   const isAccordionOpenable = () => {
     let childrenCondition = false;
@@ -49,9 +53,9 @@ const Accordion = props => {
                 isAccordionOpenable() ? '' : 'pe-none'
               }`}
               type="button"
-              data-bs-target="#collapseTarget"
+              data-bs-target={`#${accordionId}`}
               data-bs-toggle={isAccordionOpenable() ? 'collapse' : null}
-              aria-controls="collapseTarget"
+              aria-controls={accordionId}
               aria-expanded="false"
               onClick={handleAccordionClick}
             >
@@ -65,7 +69,7 @@ const Accordion = props => {
           </div>
           <div
             className="fhir-container__Accordion__data accordion-collapse collapse"
-            id="collapseTarget"
+            id={accordionId}
           >
             <div className="fhir-container__Accordion__data-text accordion-body ps-4 pt-3 pe-4 border-top">
               {bodyContent}


### PR DESCRIPTION
<!-- Add a link to the related issue here, e.g. #1234 -->
Issue:  [PATIENTAPP-99](https://1uphealth.atlassian.net/browse/PATIENTAPP-99)

---

<!-- Complete these steps to start getting this PR reviewed -->
##### PR Checklist
- [X] Give this PR a meaningful title
- [X] Add a link to the related issue at the top of this description (above)
- [X] Connect this PR with the related issue via ZenHub with the button below this text box (or at the bottom of the page after the PR is created)
- [X] Ensure your branch is up to date with the target branch and resolve any conflicts
- [X] Answer the below questions to describe your PR for reviewers
- [X] Request at least two reviewers using the "Reviewers" section on the right, usually including at least one reviewer from your team
- [X] Notify the requested reviewers in the #code-review Slack channel once the PR is ready for review

---

<!-- Answer these questions to describe the PR for reviewers -->

## Why are these changes needed?
<!-- Give context for reviewers who might not be familiar with the issue -->
The changes are needed due to the bug with opening the Accordion - when the user clicked on a single Accordion, all of the resources on the chosen page were triggered to open.

## What changed?
<!-- Tell reviewers what to expect to see in your changeset, and include screenshots for any front-end/visual changes (do not upload PHI or secrets in screenshots) -->
Currently, each of rendered Accordion components has a unique id of format `accordion-type-{resource_type}-{number}`, where `resource_type` is replaced by the resource name, which is using an Accordion.

<img width="1251" alt="Zrzut ekranu 2022-01-3 o 14 14 31" src="https://user-images.githubusercontent.com/86961707/147937077-83ded2d3-1acf-48f1-9ad8-942e25295971.png">


## How are these changes tested?
<!-- Explain how you verified these changes (unit/integration tests? manual verification?) and describe how the reviewers can verify the changes themselves (how to run the tests, what to look for in manual checks) - including regression of existing code (e.g. do all previously existing unit tests still pass?) -->
- All automatic tests are passing
- All of the changes were tested in the Patient App with a locally linked FHIR React Component library

