### PR TITLE
Refactor the Observation to display the header icon from different ways

### DIFF
--- a/src/components/resources/Observation/Observation.js
+++ b/src/components/resources/Observation/Observation.js
@@ -18,8 +18,7 @@ import {
 } from '../../ui';
 import Reference from '../../datatypes/Reference';
 
-const Observation = props => {
-  const { fhirResource } = props;
+const Observation = ({ fhirResource, fhirIcons }) => {
   const effectiveDate = _get(fhirResource, 'effectiveDateTime');
   const codeCodingDisplay = _get(fhirResource, 'code.coding.0.display');
   const codeText = _get(fhirResource, 'code.text', '');
@@ -72,7 +71,7 @@ const Observation = props => {
       <Accordion
         headerContent={
           <Header
-            resourceName={fhirResource.resourceType}
+            resourceName="Observation"
             additionalContent={
               issued && (
                 <Value label="Start date" data-testid="headerStartDate">
@@ -104,6 +103,7 @@ const Observation = props => {
                 small
               />
             }
+            icon={fhirIcons}
           />
         }
         bodyContent={

--- a/src/components/resources/Observation/Observation.stories.js
+++ b/src/components/resources/Observation/Observation.stories.js
@@ -12,32 +12,41 @@ import example3ObservationExcessSTU3 from '../../../fixtures/stu3/resources/obse
 import example1ObservationExcessR4 from '../../../fixtures/r4/resources/observation/example1.json';
 import example2ObservationExcessR4 from '../../../fixtures/r4/resources/observation/example2.json';
 import example3ObservationExcessR4 from '../../../fixtures/r4/resources/observation/example3.json';
+import ObservationIcon from '../../../assets/containers/Observation/observation.svg';
+import fhirIcons from '../../../fixtures/example-icons';
 
 export default { title: 'Observation' };
 
 export const DefaultVisualizationDSTU2 = () => {
   const fhirResource = object('Resource', exampleObservationIssued);
-  return <Observation fhirResource={fhirResource} />;
+  return (
+    <Observation
+      fhirResource={fhirResource}
+      fhirIcons={require('../../../assets/containers/Observation/observation.svg')}
+    />
+  );
 };
 
 export const ExampleWithoutIssuedDSTU2 = () => {
   const fhirResource = object('Resource', exampleObservation);
-  return <Observation fhirResource={fhirResource} />;
+  return (
+    <Observation fhirResource={fhirResource} fhirIcons={ObservationIcon} />
+  );
 };
 
 export const ExampleWithIssuedSTU3 = () => {
   const fhirResource = object('Resource', exampleObservationExcessSTU3);
-  return <Observation fhirResource={fhirResource} />;
+  return <Observation fhirResource={fhirResource} fhirIcons={fhirIcons} />;
 };
 
 export const ExampleWithoutIssuedSTU3 = () => {
   const fhirResource = object('Resource', exampleObservationSTU3);
-  return <Observation fhirResource={fhirResource} />;
+  return <Observation fhirResource={fhirResource} fhirIcons={false} />;
 };
 
 export const Example3OfSTU3 = () => {
   const fhirResource = object('Resource', example3ObservationExcessSTU3);
-  return <Observation fhirResource={fhirResource} />;
+  return <Observation fhirResource={fhirResource} fhirIcons={'random text'} />;
 };
 
 export const Example1OfR4 = () => {

--- a/src/components/resources/Observation/Observation.test.js
+++ b/src/components/resources/Observation/Observation.test.js
@@ -11,8 +11,75 @@ import exampleObservationExcessSTU3 from '../../../fixtures/stu3/resources/obser
 
 import example1ObservationExcessR4 from '../../../fixtures/r4/resources/observation/example2.json';
 import example2ObservationExcessR4 from '../../../fixtures/r4/resources/observation/example3.json';
+import fhirIcons from '../../../fixtures/example-icons';
 
 describe('should render component correctly', () => {
+  it('component without a fhirIcons props should render a default icon', () => {
+    const defaultProps = {
+      fhirResource: exampleObservationIssued,
+    };
+
+    const { getByAltText } = render(<Observation {...defaultProps} />);
+    const headerIcon = getByAltText('observation');
+
+    expect(headerIcon.getAttribute('src')).toContain('IMAGE_MOCK');
+  });
+
+  it('component with a false as a fhirIcons props should render a placeholder', () => {
+    const defaultProps = {
+      fhirResource: exampleObservationIssued,
+      fhirIcons: false,
+    };
+
+    const { getByTestId } = render(<Observation {...defaultProps} />);
+    const headerIcon = getByTestId('placeholder');
+
+    expect(headerIcon).toBeTruthy();
+  });
+
+  it('component with the img as a fhirIcons props should render an img', () => {
+    const defaultProps = {
+      fhirResource: exampleObservationIssued,
+      fhirIcons: (
+        <img
+          src={require('../assets/containers/ExplanationOfBenefit/explanation-of-benefit.svg.svg')}
+          alt="observation"
+        />
+      ),
+    };
+
+    const { getByAltText } = render(<Observation {...defaultProps} />);
+    const headerIcon = getByAltText('observation');
+
+    expect(headerIcon.getAttribute('src')).toContain('IMAGE_MOCK');
+  });
+
+  it('component with the resources object as a fhirIcons props should render an img', () => {
+    const defaultProps = {
+      fhirResource: exampleObservationIssued,
+      fhirIcons: fhirIcons,
+    };
+
+    const { getByAltText } = render(<Observation {...defaultProps} />);
+    const headerIcon = getByAltText('observation');
+
+    expect(headerIcon.getAttribute('src')).toContain('IMAGE_MOCK');
+  });
+
+  it('component with the url as a fhirIcons props should render an img', () => {
+    const avatarSrc =
+      'https://www.gravatar.com/avatar/?s=50&r=any&default=identicon&forcedefault=1';
+    const defaultProps = {
+      fhirResource: exampleObservationIssued,
+      fhirIcons: avatarSrc,
+    };
+
+    const { getByAltText } = render(<Observation {...defaultProps} />);
+    const headerIcon = getByAltText('header icon');
+
+    expect(headerIcon.getAttribute('src')).toContain(avatarSrc);
+  });
+
   test('DSTU2 renders properly', () => {
     const defaultProps = {
       fhirResource: exampleObservationIssued,

--- a/src/fixtures/example-icons.jsx
+++ b/src/fixtures/example-icons.jsx
@@ -166,7 +166,7 @@ export default {
     <img
       className="header-icon__image"
       src={require('../assets/containers/Observation/observation.svg')}
-      alt="hospital bed"
+      alt="observation"
     />
   ),
   Questionnaire: (


### PR DESCRIPTION
<!-- Add a link to the related issue here, e.g. #1234 -->
Issue:  [PATIENTAPP-97 ](https://1uphealth.atlassian.net/jira/software/projects/PATIENTAPP/boards/33?selectedIssue=PATIENTAPP-97)

---

<!-- Complete these steps to start getting this PR reviewed -->
##### PR Checklist
- [x] Give this PR a meaningful title
- [x] Add a link to the related issue at the top of this description (above)
- [x] Connect this PR with the related issue via ZenHub with the button below this text box (or at the bottom of the page after the PR is created)
- [x] Ensure your branch is up to date with the target branch and resolve any conflicts
- [x] Answer the below questions to describe your PR for reviewers
- [x] Request at least two reviewers using the "Reviewers" section on the right, usually including at least one reviewer from your team
- [ ] Notify the requested reviewers in the #code-review Slack channel once the PR is ready for review

---

<!-- Answer these questions to describe the PR for reviewers -->

## Why are these changes needed?
<!-- Give context for reviewers who might not be familiar with the issue -->
Because the icons in the Observation component are not working. 

## What changed?
<!-- Tell reviewers what to expect to see in your changeset, and include screenshots for any front-end/visual changes (do not upload PHI or secrets in screenshots) -->
An icon has been added in the header props in the Observation component.
Added the string "Observation" as a resourceName in the header props in the Observation component.
Icons have been added to the Observation stories from various sources.

## How are these changes tested?
<!-- Explain how you verified these changes (unit/integration tests? manual verification?) and describe how the reviewers can verify the changes themselves (how to run the tests, what to look for in manual checks) - including regression of existing code (e.g. do all previously existing unit tests still pass?) -->
The changes have been tested by unit tests and the storybook.