### PR TITLE
[PATIENTAPP-168] If productOrService is absent, populate revenue code as Service in Services section

### DIFF
--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
@@ -126,7 +126,9 @@ const r4DTO = fhirResource => {
    */
   const prepareServiceItem = services =>
     services.map(serviceItem => {
-      const coding = _get(serviceItem, 'revenue.coding.0');
+      const coding =
+        _get(serviceItem, 'revenue.coding.0') ||
+        _get(serviceItem, 'productOrService.coding.0');
       const servicedDate = _get(serviceItem, 'servicedDate');
       const servicedPeriod = _get(serviceItem, 'servicedPeriod');
       const quantity = _get(serviceItem, 'quantity.value');

--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.js
@@ -126,7 +126,7 @@ const r4DTO = fhirResource => {
    */
   const prepareServiceItem = services =>
     services.map(serviceItem => {
-      const coding = _get(serviceItem, 'productOrService.coding.0');
+      const coding = _get(serviceItem, 'revenue.coding.0');
       const servicedDate = _get(serviceItem, 'servicedDate');
       const servicedPeriod = _get(serviceItem, 'servicedPeriod');
       const quantity = _get(serviceItem, 'quantity.value');

--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.test.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.test.js
@@ -178,7 +178,7 @@ describe('should render ExplanationOfBenefit component properly', () => {
     const explanationService = getAllByTestId('explanation.service').map(
       n => n.textContent,
     );
-    const expectedArray = [' ', ' '];
+    const expectedArray = ['(1205)', '(group)'];
     explanationService.forEach((x, i) => expect(x).toContain(expectedArray[i]));
 
     const explanationServicedDate = getAllByTestId(
@@ -299,7 +299,11 @@ describe('should render ExplanationOfBenefit component properly', () => {
     const explanationService = getAllByTestId('explanation.service').map(
       n => n.textContent,
     );
-    const expectedArray = [' ', ' ', ' '];
+    const expectedArray = [
+      'Encounter for symptom (185345009)',
+      'Acute bronchitis (disorder) (10509002)',
+      'Measurement of respiratory function (procedure) (23426006)',
+    ];
     const replaceWhitespaces = text => text.replace(/\s+/g, ' ');
     explanationService.forEach((x, i) => {
       expect(replaceWhitespaces(x)).toEqual(

--- a/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.test.js
+++ b/src/components/resources/ExplanationOfBenefit/ExplanationOfBenefit.test.js
@@ -178,7 +178,7 @@ describe('should render ExplanationOfBenefit component properly', () => {
     const explanationService = getAllByTestId('explanation.service').map(
       n => n.textContent,
     );
-    const expectedArray = ['(1205)', '(group)'];
+    const expectedArray = [' ', ' '];
     explanationService.forEach((x, i) => expect(x).toContain(expectedArray[i]));
 
     const explanationServicedDate = getAllByTestId(
@@ -299,11 +299,7 @@ describe('should render ExplanationOfBenefit component properly', () => {
     const explanationService = getAllByTestId('explanation.service').map(
       n => n.textContent,
     );
-    const expectedArray = [
-      'Encounter for symptom (185345009)',
-      'Acute bronchitis (disorder) (10509002)',
-      'Measurement of respiratory function (procedure) (23426006)',
-    ];
+    const expectedArray = [' ', ' ', ' '];
     const replaceWhitespaces = text => text.replace(/\s+/g, ' ');
     explanationService.forEach((x, i) => {
       expect(replaceWhitespaces(x)).toEqual(


### PR DESCRIPTION
<!-- Add a link to the related issue here, e.g. #1234 -->
Issue:  [PATIENTAPP-168](https://1uphealth.atlassian.net/browse/PATIENTAPP-168)

---

<!-- Complete these steps to start getting this PR reviewed -->
##### PR Checklist
- [x] Give this PR a meaningful title
- [x] Add a link to the related issue at the top of this description (above)
- [ ] Connect this PR with the related issue via ZenHub with the button below this text box (or at the bottom of the page after the PR is created)
- [x] Ensure your branch is up to date with the target branch and resolve any conflicts
- [x] Answer the below questions to describe your PR for reviewers
- [ ] Request at least two reviewers using the "Reviewers" section on the right, usually including at least one reviewer from your team
- [ ] Notify the requested reviewers in the #code-review Slack channel once the PR is ready for review

---

<!-- Answer these questions to describe the PR for reviewers -->

## Why are these changes needed?
<!-- Give context for reviewers who might not be familiar with the issue -->
The productOrService might not be present and the resulting information might not be accurate

## What changed?
<!-- Tell reviewers what to expect to see in your changeset, and include screenshots for any front-end/visual changes (do not upload PHI or secrets in screenshots) -->
Use item.revenue data first, then use item.productOrService

## How are these changes tested?
<!-- Explain how you verified these changes (unit/integration tests? manual verification?) and describe how the reviewers can verify the changes themselves (how to run the tests, what to look for in manual checks) - including regression of existing code (e.g. do all previously existing unit tests still pass?) -->
- Tests are passing
- Correct data is shown.