### PR TITLE
Add Note (annotation) support to Observation resources.

### DIFF
--- a/src/components/resources/Observation/Observation.js
+++ b/src/components/resources/Observation/Observation.js
@@ -18,6 +18,7 @@ import {
 } from '../../ui';
 import Reference from '../../datatypes/Reference';
 import { getResourceDate } from '../../../utils/getResourceDate';
+import Annotation from "../../datatypes/Annotation";
 
 const Observation = ({
   fhirResource,
@@ -50,6 +51,9 @@ const Observation = ({
   let valueQuantityValueNumber = valueQuantityValue;
 
   const subject = _get(fhirResource, 'subject');
+  const note = _get(fhirResource, 'note');
+  const hasNote = Array.isArray(note);
+
   const tableData = [
     {
       label: 'Issued on',
@@ -70,6 +74,12 @@ const Observation = ({
         <Coding fhirData={coding} key={`value-coding-${i}`} />
       )),
       status: !_isEmpty(valueCodeableConceptCoding),
+    },
+    {
+      label: 'Notes',
+      testId: 'hasNote',
+      data: hasNote && <Annotation fhirData={note} />,
+      status: hasNote,
     },
   ];
 

--- a/src/components/resources/Observation/Observation.test.js
+++ b/src/components/resources/Observation/Observation.test.js
@@ -132,6 +132,7 @@ describe('should render component correctly', () => {
     expect(getByTestId('issuedOn').textContent).toEqual('05/18/2016');
     expect(getByTestId('subject').textContent).toContain('Patient/infant');
     expect(queryByText(/373066001/g)).not.toBeNull();
+    expect(getByTestId('hasNote').textContent).toContain('Was exposed to second-hand smoke.');
   });
 
   test('should display not rounded value', () => {

--- a/src/fixtures/r4/resources/observation/example3.json
+++ b/src/fixtures/r4/resources/observation/example3.json
@@ -46,5 +46,10 @@
       }
     ],
     "text": "YES"
-  }
+  },
+  "note": [
+    {
+      "text": "Was exposed to second-hand smoke."
+    }
+  ]
 }


### PR DESCRIPTION
<!-- Add a link to the related issue here, e.g. #1234 -->
Issue:  

---

<!-- Complete these steps to start getting this PR reviewed -->
##### PR Checklist
- [x] Give this PR a meaningful title
- [ ] Add a link to the related issue at the top of this description (above)
- [ ] Connect this PR with the related issue via ZenHub with the button below this text box (or at the bottom of the page after the PR is created)
- [x] Ensure your branch is up to date with the target branch and resolve any conflicts
- [x] Answer the below questions to describe your PR for reviewers
- [ ] Request at least two reviewers using the "Reviewers" section on the right, usually including at least one reviewer from your team
- [ ] Notify the requested reviewers in the #code-review Slack channel once the PR is ready for review

---

<!-- Answer these questions to describe the PR for reviewers -->

## Why are these changes needed?
<!-- Give context for reviewers who might not be familiar with the issue -->
In order to fully support FHIR we need to add support for Notes (using the `Annotation` datatype) in the `Observation` component. See this page in the [FHIR standard for more info](https://www.hl7.org/fhir/observation-definitions.html#Observation.note).

## What changed?
<!-- Tell reviewers what to expect to see in your changeset, and include screenshots for any front-end/visual changes (do not upload PHI or secrets in screenshots) -->
Notes should appear in the data table for the `Observation` component. 

## How are these changes tested?
<!-- Explain how you verified these changes (unit/integration tests? manual verification?) and describe how the reviewers can verify the changes themselves (how to run the tests, what to look for in manual checks) - including regression of existing code (e.g. do all previously existing unit tests still pass?) -->
Added a unit test and updated the data in the `observation/example3.json` file. You should be able to use storybook and select R4 example 3 to preview these changes. It mirrors the work done for `AllergyIntolerance` so this is consistent with previous work.

